### PR TITLE
Setup Deployment with Nanobox

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,73 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
 Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
 
+## Nanobox Setup
+
+### System Requirements
+
+- [Docker](https://docs.docker.com/engine/installation/linux/)
+- Add your user to the docker group ([instructions](https://docs.docker.com/engine/installation/linux/linux-postinstall/))
+
+### Download the Nanobox Package
+
+Download the Nanobox package appropriate for your Linux distribution from the [Nanobox downloads page](https://dashboard.nanobox.io/download). Unpack and install the package as you normally install packages in your specific distro.
+
+After having the Nanobox Package installed, you can build the project with:
+
+```
+$ nanobox run
+```
+
+### Run & Setup Nanobox
+
+The first time you run any Nanobox command, it will walk you through an initial setup process specifying options for your local environment. The first question it will ask you is how you would like to run Nanobox. Select the `Via Docker Native` option.
+
+### Add a local DNS
+
+Add a convenient way to access your app from the browser:
+
+```
+nanobox dns add local phoenix.local
+```
+
+### Start Hacking!
+
+With Nanobox installed, the [Getting Started Guides](https://guides.nanobox.io/) walk you through getting popular languages and frameworks up and running with Nanobox.
+
+### Environment variables
+
+To add environment variables to production:
+
+```
+$ nanobox evar add remote PORT=8080
+```
+
+To add environment variables to your local environment:
+
+```
+$ nanobox evar add local PORT=8080
+```
+
+To list local variables:
+
+```
+$ nanobox evar ls local
+```
+
+## Deploy your app
+
+### Add a remote
+
+```
+$ nanobox remote add baltimore-ai
+```
+
+### Deploy
+
+```
+$ nanobox deploy
+```
+
 ## Learn more
 
   * Official website: http://www.phoenixframework.org/

--- a/boxfile.yml
+++ b/boxfile.yml
@@ -1,0 +1,44 @@
+run.config:
+  # elixir runtime
+  engine: elixir
+  engine.config:
+    runtime: elixir-1.5
+
+  # ensure inotify exists for hot-code reloading
+  dev_packages:
+    - inotify-tools
+
+  # packages available in prod and dev envs
+  extra_packages:
+    - nodejs
+    - git
+
+  # cache node_modules
+  cache_dirs:
+    - assets/node_modules
+
+  # add node_module bins to the $PATH
+  extra_path_dirs:
+    - assets/node_modules/.bin
+
+  # enable the filesystem watcher
+  fs_watch: true
+
+deploy.config:
+  # just before the new process comes online,
+  # let's migrate the database
+  before_live:
+    web.main:
+      - mix phx.digest
+      - mix ecto.create --quiet
+      - mix ecto.migrate
+
+# services
+data.db:
+  image: nanobox/postgresql
+
+web.main:
+  start: node-start mix phx.server
+  writable_dirs:
+    - _build/
+    - priv/static/

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -58,4 +58,10 @@ config :phoenix, :stacktrace_depth, 20
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
 
-import_config "dev.secret.exs"
+config :baltimore_ai, BaltimoreAi.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: System.get_env("DATA_DB_USER"),
+  password: System.get_env("DATA_DB_PASS"),
+  hostname: System.get_env("DATA_DB_HOST"),
+  database: "baltimore_ai_dev",
+  pool_size: 10

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -68,4 +68,11 @@ config :logger, level: :info
 
 # Finally import the config/prod.secret.exs which should be versioned
 # separately.
-import_config "prod.secret.exs"
+
+config :baltimore_ai, BaltimoreAi.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: System.get_env("DATA_DB_USER"),
+  password: System.get_env("DATA_DB_PASS"),
+  hostname: System.get_env("DATA_DB_HOST"),
+  database: "baltimore_ai_prod",
+  pool_size: 10

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,14 +9,15 @@ config :baltimore_ai, BaltimoreAiWeb.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-# Configure your database
-config :baltimore_ai, BaltimoreAi.Repo,
-  database: "baltimore_ai_test",
-  hostname: "localhost",
-  pool: Ecto.Adapters.SQL.Sandbox
-
 # Ueberauth Config for oauth
 config :ueberauth, Ueberauth,
   providers: [ google: { Ueberauth.Strategy.Google, [default_scope: "emails profile plus.me"] } ]
 
-import_config 'test.secret.exs'
+# Configure your database
+config :baltimore_ai, BaltimoreAi.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: System.get_env("DATA_DB_USER"),
+  password: System.get_env("DATA_DB_PASS"),
+  hostname: System.get_env("DATA_DB_HOST"),
+  database: "baltimore_ai_test",
+  pool: Ecto.Adapters.SQL.Sandbox


### PR DESCRIPTION
Description
-----------

Basic deployment setup with [Nanobox](https://nanobox.io/)

Changes
-------

- Added boxfile with local and production env configs

Notes:
---------
- DNS and SSL certificate can be added through Nanobox dashboard.
- Live site is running on: http://baltimore-ai-baltimore-ai.nanoapp.io/
- Google OAuth client keys should be exchanged later on Nanobox dashboard.