### PR TITLE
Add ability to publish offers

### DIFF
--- a/lib/baltimore_ai/abilities.ex
+++ b/lib/baltimore_ai/abilities.ex
@@ -9,13 +9,7 @@ defimpl Canada.Can, for: BaltimoreAi.Accounts.User do
 
   def can?(%User{admin: true}, _, _), do: true
 
-  def can?(%User{id: id}, action, %Listing{poster_id: poster_id}) when action in [
-    :unpublished_listings,
-    :unpublished_search,
-    :edit,
-    :update,
-    :delete
-  ] do
+  def can?(%User{id: id}, action, %Listing{poster_id: poster_id}) when action in [:edit, :update, :delete] do
     id == poster_id
   end
 

--- a/lib/baltimore_ai/abilities.ex
+++ b/lib/baltimore_ai/abilities.ex
@@ -7,7 +7,15 @@ defimpl Canada.Can, for: BaltimoreAi.Accounts.User do
 
   import Ecto.Query
 
-  def can?(%User{id: id}, action, %Listing{poster_id: poster_id}) when action in [:edit, :update, :delete] do
+  def can?(%User{admin: true}, _, _), do: true
+
+  def can?(%User{id: id}, action, %Listing{poster_id: poster_id}) when action in [
+    :unpublished_listings,
+    :unpublished_search,
+    :edit,
+    :update,
+    :delete
+  ] do
     id == poster_id
   end
 
@@ -28,5 +36,6 @@ defimpl Canada.Can, for: BaltimoreAi.Accounts.User do
 
     Repo.all(query) != []
   end
+
 
 end

--- a/lib/baltimore_ai/accounts/user.ex
+++ b/lib/baltimore_ai/accounts/user.ex
@@ -12,6 +12,7 @@ defmodule BaltimoreAi.Accounts.User do
     field :token, :string
     field :hashed_password, :string
     field :permissions, :map
+    field :admin, :boolean, default: false
     field :password, :string, virtual: true
 
     has_many(:listings, BaltimoreAi.Jobs.Listing, foreign_key: :poster_id)

--- a/lib/baltimore_ai/jobs/jobs.ex
+++ b/lib/baltimore_ai/jobs/jobs.ex
@@ -126,7 +126,7 @@ defmodule BaltimoreAi.Jobs do
   def filter_unpublished_offers(filters, page) do
     Listing
     |> ListingQuery.unpublished()
-    |> ListingQuery.order_published()
+    |> ListingQuery.order_inserted()
     |> ListingQuery.by_text(filters["text"])
     |> Repo.paginate(page: page)
   end

--- a/lib/baltimore_ai/jobs/jobs.ex
+++ b/lib/baltimore_ai/jobs/jobs.ex
@@ -33,6 +33,18 @@ defmodule BaltimoreAi.Jobs do
     end
   end
 
+  def list_unpublished_listings(page \\ nil) do
+    query = ListingQuery.unpublished(Listing)
+
+    case page do
+      page_no when is_integer(page_no) and page_no > 0 ->
+        Repo.paginate(query, page: page)
+
+      _ ->
+        Repo.all(query)
+    end
+  end
+
   @doc """
   Returns the list of published offers.
 
@@ -106,6 +118,14 @@ defmodule BaltimoreAi.Jobs do
   def filter_published_offers(filters, page) do
     Listing
     |> ListingQuery.published()
+    |> ListingQuery.order_published()
+    |> ListingQuery.by_text(filters["text"])
+    |> Repo.paginate(page: page)
+  end
+
+  def filter_unpublished_offers(filters, page) do
+    Listing
+    |> ListingQuery.unpublished()
     |> ListingQuery.order_published()
     |> ListingQuery.by_text(filters["text"])
     |> Repo.paginate(page: page)

--- a/lib/baltimore_ai/jobs/listing.ex
+++ b/lib/baltimore_ai/jobs/listing.ex
@@ -36,7 +36,7 @@ defmodule BaltimoreAi.Jobs.Listing do
 
   def changeset_update(listing, attrs) do
     listing
-    |> cast(attrs, [:title, :external_url, :description, :job_place, :job_type, :location])
+    |> cast(attrs, [:title, :external_url, :description, :job_place, :job_type, :location, :published_at])
     |> cast_assoc(:company)
     |> validate_required(:title)
     |> validate_length(:title, min: 5, max: 50)

--- a/lib/baltimore_ai/jobs/queries/listing.ex
+++ b/lib/baltimore_ai/jobs/queries/listing.ex
@@ -51,14 +51,14 @@ defmodule BaltimoreAi.Jobs.Queries.Listing do
   end
 
   def unpublished(query) do
-    from o in query, where: is_nil(o.published_at)
+    from o in query, where: is_nil(o.published_at), preload: [:company]
   end
 
   def order_published(query) do
-    from o in query, order_by: [desc: o.published_at]
+    from o in query, order_by: [desc: o.published_at], preload: [:company]
   end
 
   def order_inserted(query) do
-    from o in query, order_by: [desc: o.inserted_at]
+    from o in query, order_by: [desc: o.inserted_at], preload: [:company]
   end
 end

--- a/lib/baltimore_ai_web/controllers/listing_controller.ex
+++ b/lib/baltimore_ai_web/controllers/listing_controller.ex
@@ -6,7 +6,12 @@ defmodule BaltimoreAiWeb.ListingController do
 
   @filters_available ["text", "job_type", "job_place"]
 
-  plug :load_and_authorize_resource, model: Listing, only: [:edit, :update, :delete]
+  plug(
+    :load_and_authorize_resource,
+    model: Listing,
+    only: [:edit, :update, :delete],
+    non_id_actions: [:unpublished_search, :unpublished_listings]
+  )
 
   def index(conn, params) do
     page_number = get_page_number(params)
@@ -18,6 +23,18 @@ defmodule BaltimoreAiWeb.ListingController do
     |> assign(:page_number, page.page_number)
     |> assign(:total_pages, page.total_pages)
     |> render("index.html")
+  end
+
+  def unpublished_listings(conn, params) do
+    page_number = get_page_number(params)
+
+    page = Jobs.list_unpublished_listings(page_number)
+
+    conn
+    |> assign(:listings, page.entries)
+    |> assign(:page_number, page.page_number)
+    |> assign(:total_pages, page.total_pages)
+    |> render("unpublished_listings.html")
   end
 
   def new(conn, _params) do
@@ -91,6 +108,32 @@ defmodule BaltimoreAiWeb.ListingController do
       |> Enum.into(%{})
 
     page = Jobs.filter_published_offers(filters, page_number)
+
+    conn
+    |> assign(:offers, page.entries)
+    |> assign(:page_number, page.page_number)
+    |> assign(:total_pages, page.total_pages)
+    |> render("search.html")
+  end
+
+  def unpublished_search(conn, params) do
+    page_number = get_page_number(params)
+
+    filters =
+      params
+      |> Map.get("filters", %{})
+      |> Enum.reduce(%{}, fn {k, v}, acc ->
+        case {k, v} do
+          {key, _} when key not in @filters_available -> acc
+          {_, val} when val in ["", nil] -> acc
+          {key, str} when is_binary(str) -> Map.put(acc, key, String.trim(str))
+          {key, val} -> Map.put(acc, key, val)
+        end
+      end)
+      |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
+      |> Enum.into(%{})
+
+    page = Jobs.filter_unpublished_offers(filters, page_number)
 
     conn
     |> assign(:offers, page.entries)

--- a/lib/baltimore_ai_web/controllers/listing_controller.ex
+++ b/lib/baltimore_ai_web/controllers/listing_controller.ex
@@ -127,29 +127,39 @@ defmodule BaltimoreAiWeb.ListingController do
   end
 
   def unpublished_search(conn, params) do
-    page_number = get_page_number(params)
+    current_user = Guardian.Plug.current_resource(conn)
 
-    filters =
-      params
-      |> Map.get("filters", %{})
-      |> Enum.reduce(%{}, fn {k, v}, acc ->
-        case {k, v} do
-          {key, _} when key not in @filters_available -> acc
-          {_, val} when val in ["", nil] -> acc
-          {key, str} when is_binary(str) -> Map.put(acc, key, String.trim(str))
-          {key, val} -> Map.put(acc, key, val)
-        end
-      end)
-      |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
-      |> Enum.into(%{})
+    if current_user && current_user.admin do
+      page_number = get_page_number(params)
 
-    page = Jobs.filter_unpublished_offers(filters, page_number)
+      filters =
+        params
+        |> Map.get("filters", %{})
+        |> Enum.reduce(%{}, fn {k, v}, acc ->
+          case {k, v} do
+            {key, _} when key not in @filters_available -> acc
+            {_, val} when val in ["", nil] -> acc
+            {key, str} when is_binary(str) -> Map.put(acc, key, String.trim(str))
+            {key, val} -> Map.put(acc, key, val)
+          end
+        end)
+        |> Enum.reject(fn {_, v} -> is_nil(v) or v == "" end)
+        |> Enum.into(%{})
 
-    conn
-    |> assign(:offers, page.entries)
-    |> assign(:page_number, page.page_number)
-    |> assign(:total_pages, page.total_pages)
-    |> render("search.html")
+      page = Jobs.filter_unpublished_offers(filters, page_number)
+
+      conn
+      |> assign(:offers, page.entries)
+      |> assign(:page_number, page.page_number)
+      |> assign(:total_pages, page.total_pages)
+      |> render("unpublished_search.html")
+
+    else
+      conn
+      |> put_flash(:info, "Access Denied")
+      |> redirect(to: Routes.listing_path(conn, :index))
+
+    end
   end
 
   defp get_page_number(params) do

--- a/lib/baltimore_ai_web/router.ex
+++ b/lib/baltimore_ai_web/router.ex
@@ -31,8 +31,11 @@ defmodule BaltimoreAiWeb.Router do
     get "/login", SessionController, :new
     post "/login", SessionController, :create
     get "/page/:page", ListingController, :index, as: :offer_page
-    get "/listings/place/:filter", ListingController, :index_filtered
-    get "/listings/type/:filter", ListingController, :index_filtered
+
+    # TODO: not implemented yet
+    # get "/listings/place/:filter", ListingController, :index_filtered
+    # get "/listings/type/:filter", ListingController, :index_filtered
+
     get "/search", ListingController, :search
 
     get "/about", PageController, :about
@@ -50,7 +53,9 @@ defmodule BaltimoreAiWeb.Router do
     pipe_through [:browser, :auth, :ensure_auth]
 
     resources "/listings", ListingController, only: [:new, :create, :edit, :update, :delete]
+    get "/unpublished_search", ListingController, :unpublished_search
     get "/listings/:slug_or_id", ListingController, :show
+    get "/unpublished_listings", ListingController, :unpublished_listings
     delete "/logout", SessionController, :delete
     resources "/users", UserController
     resources "/companies", CompanyController

--- a/lib/baltimore_ai_web/templates/listing/_unpublished_filters.html.eex
+++ b/lib/baltimore_ai_web/templates/listing/_unpublished_filters.html.eex
@@ -1,0 +1,29 @@
+<nav class="level">
+  <div class="level-left">
+    <div class="level-item">
+      <%= gettext("Showing page %{page} of %{total_pages}", page: @page_number, total_pages: @total_pages) %>
+    </div>
+  </div>
+
+  <div class="level-right">
+    <p class="level-item">
+      <%= form_for @conn, Routes.listing_path(@conn, :unpublished_search), [as: :filters, method: :get, class: "filters #{@aspect}"], fn f -> %>
+        <div class="field is-grouped">
+          <p class="control is-expanded has-icons-left">
+            <%= text_input(f, :text,
+                  id: "filter_text",
+                  class: "input is-rounded",
+                  placeholder: gettext("Search by title, workplace, type")) %>
+            <span class="icon is-small is-left">
+              <i class="fas fa-search"></i>
+            </span>
+          </p>
+          <p class="control">
+            <%= submit(gettext("Search"), class: "button is-rounded is-info") %>
+          </p>
+        </div>
+      <% end %>
+    </p>
+  </div>
+</nav>
+<hr class="divider" />

--- a/lib/baltimore_ai_web/templates/listing/edit.html.eex
+++ b/lib/baltimore_ai_web/templates/listing/edit.html.eex
@@ -1,5 +1,3 @@
 <h1>Edit Listing</h1>
 
 <%= render "form.html", Map.put(assigns, :action, Routes.listing_path(@conn, :update, @listing)) %>
-
-<span><%= link "Back", to: Routes.listing_path(@conn, :index) %></span>

--- a/lib/baltimore_ai_web/templates/listing/form.html.eex
+++ b/lib/baltimore_ai_web/templates/listing/form.html.eex
@@ -105,10 +105,28 @@
                 id: "offer_summary",
                 class: "textarea",
                 placeholder: gettext("Description (max 450 characters)")) %>
-          <%= error_tag(f, :summary) %>
+          <%= error_tag(f, :description) %>
         </div>
       </div>
     </div>
+
+    <%= if @conn.assigns.current_user.admin do %>
+      <div class="field is-horizontal">
+        <div class="field-label is-normal">
+          <label class="label"><%= gettext("Published At") %></label>
+        </div>
+        <div class="field-body">
+          <div class="field">
+            <%= datetime_select(f, :published_at,
+              id: "offer_published_at",
+              class: "input is-medium",
+              value: Timex.now
+            ) %>
+            <%= error_tag(f, :published_at) %>
+          </div>
+        </div>
+      </div>
+    <% end %>
 
     <div class="field is-horizontal">
       <div class="field-label">

--- a/lib/baltimore_ai_web/templates/listing/unpublished_listings.html.eex
+++ b/lib/baltimore_ai_web/templates/listing/unpublished_listings.html.eex
@@ -1,0 +1,11 @@
+<%= render("_unpublished_filters.html", conn: @conn, aspect: "small", page_number: @page_number, total_pages: @total_pages) %>
+
+<%= for listing <- @listings do %>
+  <%= render("_listing.html", conn: @conn, listing: listing, details: false) %>
+<% end %>
+
+<%= if length(@listings) == 0 do %>
+  <%= render("_no-listing.html", conn: @conn) %>
+<% end %>
+
+<%= render("_pagination.html", conn: @conn, page_number: @page_number, total_pages: @total_pages) %>

--- a/lib/baltimore_ai_web/templates/listing/unpublished_search.html.eex
+++ b/lib/baltimore_ai_web/templates/listing/unpublished_search.html.eex
@@ -1,0 +1,11 @@
+<%= render("_unpublished_filters.html", conn: @conn, aspect: "small", page_number: @page_number, total_pages: @total_pages) %>
+
+<%= for listing <- @offers do %>
+  <%= render("_listing.html", conn: @conn, listing: listing, details: false) %>
+<% end %>
+
+<%= if length(@offers) == 0 do %>
+  <%= render("_no-listing.html", conn: @conn) %>
+<% end %>
+
+<%= render("_pagination.html", conn: @conn, page_number: @page_number, total_pages: @total_pages) %>

--- a/lib/baltimore_ai_web/templates/shared/_navbar.html.eex
+++ b/lib/baltimore_ai_web/templates/shared/_navbar.html.eex
@@ -14,6 +14,9 @@
     <div id="navbarMenu" class="navbar-menu">
       <div class="navbar-start">
         <a class="navbar-item" href="<%= Routes.listing_path(@conn, :new) %>"><%= gettext "Publish an offer" %></a>
+        <%= if @conn.assigns.current_user && @conn.assigns.current_user.admin do %>
+          <a class="navbar-item" href="<%= Routes.listing_path(@conn, :unpublished_listings) %>"><%= gettext "Unpublished offers" %></a>
+        <% end %>
         <a class="navbar-item" href="<%= Routes.page_path(@conn, :about) %>"><%= gettext "About" %></a>
       </div>
       <div class="navbar-end">

--- a/priv/repo/migrations/20190307000305_add_admin_to_users.exs
+++ b/priv/repo/migrations/20190307000305_add_admin_to_users.exs
@@ -1,0 +1,9 @@
+defmodule BaltimoreAi.Repo.Migrations.AddAdminToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :admin, :boolean, default: false
+    end
+  end
+end


### PR DESCRIPTION
Description
-----------

This should allow admins to publish job offers.

Use-cases
--------

- As an admin I should see a new menu _Unpublished Offers_ so I can view the offers that were not published yet.
- As an admin I should be allowed to create/read/update/delete any resources.
- As an admin I should be able to search offers that were not published.

Changes
-------

- Add `admin` field to users.
- Update abilities to alow admin to perform any actions in any resources.
- Add endpoint to list unpublished listings.
- Add endpoint to search by unpublished listings.
- Add `published_at` field to listing form when user is an admin.
- Include new endpoints to permissions check so non admins should not be able to access the url manually