### PR TITLE
Phase 3: claim flow + magic-link auth + admin moderation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,42 @@ jobs:
       - name: Scan for security vulnerabilities in JavaScript dependencies
         run: bin/importmap audit
 
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Prepare database
+        run: bin/rails db:prepare
+
+      - name: Run tests
+        run: bin/rails test
+
   lint:
     runs-on: ubuntu-latest
     env:

--- a/Gemfile
+++ b/Gemfile
@@ -60,4 +60,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Preview emails in the browser instead of sending them
+  gem "letter_opener"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -89,6 +91,8 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -143,6 +147,12 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.1)
@@ -213,6 +223,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    public_suffix (7.0.5)
     puma (8.0.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -381,6 +392,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   kamal
+  letter_opener
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,4 @@
+class Admin::BaseController < ApplicationController
+  layout "admin"
+  before_action :require_admin!
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,9 @@
+class Admin::DashboardController < Admin::BaseController
+  def index
+    @pending_count = ProfileClaim.pending_review.count
+    @stale_count   = ProfileClaim.stale_pending.count
+    @total_companies = Company.count
+    @published_companies = Company.published.count
+    @claimed_companies = Company.where(claimed: true).count
+  end
+end

--- a/app/controllers/admin/profile_claims_controller.rb
+++ b/app/controllers/admin/profile_claims_controller.rb
@@ -1,0 +1,49 @@
+class Admin::ProfileClaimsController < Admin::BaseController
+  before_action :set_claim, only: [ :show, :approve, :reject ]
+
+  def index
+    @pending = ProfileClaim.pending_review.includes(:company).order(created_at: :asc)
+    @recent  = ProfileClaim.where.not(review_status: "pending_review").includes(:company).order(updated_at: :desc).limit(20)
+  end
+
+  def show
+  end
+
+  def approve
+    user = User.find_or_initialize_by(email: @claim.email)
+    user.role ||= "owner"
+    Company.transaction do
+      user.save!
+      @claim.company.update!(
+        user: user,
+        claimed: true,
+        status: @claim.company.status == "draft" ? "published" : @claim.company.status,
+        last_verified_at: Time.current
+      )
+      @claim.update!(
+        review_status: "approved",
+        reviewed_by: current_user.email,
+        reviewed_at: Time.current,
+        completed_at: Time.current,
+        current_step: "done"
+      )
+    end
+    ProfileClaimMailer.welcome(user, @claim.company).deliver_later
+    redirect_to admin_profile_claims_path, notice: "Approved #{@claim.company.name}."
+  end
+
+  def reject
+    @claim.update!(
+      review_status: "rejected",
+      reviewed_by: current_user.email,
+      reviewed_at: Time.current
+    )
+    redirect_to admin_profile_claims_path, notice: "Rejected claim for #{@claim.company.name}."
+  end
+
+  private
+
+  def set_claim
+    @claim = ProfileClaim.includes(:company).find(params[:id])
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,44 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   stale_when_importmap_changes
 
-  helper_method :canonical_url
+  helper_method :canonical_url, :current_user, :signed_in?
 
   private
 
   def canonical_url(path = request.path)
     URI.join(request.base_url, path).to_s
+  end
+
+  def current_user
+    @current_user ||= authenticate_from_cookie
+  end
+
+  def signed_in?
+    current_user.present?
+  end
+
+  def authenticate_from_cookie
+    token = cookies.signed[:session_token]
+    return nil if token.blank?
+    User.find_by_session_token(token)
+  end
+
+  def sign_in_as(user)
+    cookies.signed.permanent[:session_token] = {
+      value: user.session_token,
+      httponly: true,
+      same_site: :lax,
+      secure: Rails.env.production?
+    }
+    @current_user = user
+  end
+
+  def sign_out!
+    cookies.delete(:session_token)
+    @current_user = nil
+  end
+
+  def require_admin!
+    redirect_to root_path, alert: "Not authorized." unless current_user&.admin?
   end
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,15 +1,52 @@
 class CompaniesController < ApplicationController
+  before_action :set_company, only: [ :show, :edit, :update ]
+  before_action :require_owner!, only: [ :edit, :update ]
+
   def index
     @companies = Company.published.includes(:tags).order(name: :asc)
     @category_counts = Company.published.group(:primary_category).count
   end
 
   def show
-    @company = Company.published.includes(:tags).find_by!(slug: params[:slug])
     @similar_companies = Company.published
                                 .where(primary_category: @company.primary_category)
                                 .where.not(id: @company.id)
                                 .order(updated_at: :desc)
                                 .limit(5)
+  end
+
+  def edit
+  end
+
+  def update
+    if @company.update(company_params)
+      @company.tag_ids = Array(params[:tag_ids]).reject(&:blank?).map(&:to_i) if params.key?(:tag_ids)
+      @company.update!(last_verified_at: Time.current)
+      redirect_to company_path(@company), notice: "Listing updated."
+    else
+      flash.now[:alert] = @company.errors.full_messages.to_sentence
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_company
+    scope = (action_name == "show") ? Company.published : Company.all
+    @company = scope.includes(:tags).find_by!(slug: params[:slug])
+  end
+
+  def require_owner!
+    unless signed_in? && current_user.company&.id == @company.id
+      redirect_to (signed_in? ? root_path : sign_in_request_path), alert: "Not authorized."
+    end
+  end
+
+  def company_params
+    params.expect(company: [
+      :tagline, :description, :website,
+      :linkedin_url, :github_url, :crunchbase_url, :twitter_url,
+      :city, :state, :founded_year, :employee_count_bucket
+    ])
   end
 end

--- a/app/controllers/profile_claims_controller.rb
+++ b/app/controllers/profile_claims_controller.rb
@@ -1,0 +1,162 @@
+class ProfileClaimsController < ApplicationController
+  WIZARD_STEPS = %w[basics story links tags].freeze
+
+  before_action :set_company
+  before_action :reject_already_claimed!
+  before_action :set_claim_for_wizard, only: [ :show_step, :update_step ]
+
+  def start
+  end
+
+  def send_code
+    email = params[:email].to_s.strip.downcase
+    name  = params[:claimant_name].to_s.strip
+
+    if email.blank? || !email.match?(URI::MailTo::EMAIL_REGEXP)
+      redirect_to claim_path(@company), alert: "Enter a valid email address."
+      return
+    end
+
+    @claim = ProfileClaim.find_or_initialize_by(company: @company, email: email)
+    @claim.claimant_name = name if name.present?
+    @claim.review_status ||= "pending"
+    @claim.current_step  ||= "verify"
+
+    unless @claim.persisted? || @claim.save
+      redirect_to claim_path(@company), alert: @claim.errors.full_messages.to_sentence
+      return
+    end
+
+    unless @claim.can_send_code?
+      redirect_to claim_path(@company),
+        alert: "Slow down — try again in #{@claim.cooldown_seconds_remaining}s." and return
+    end
+
+    code = @claim.generate_verification_code!
+    ProfileClaimMailer.verification_code(@claim, code).deliver_later
+    session[:profile_claim_id] = @claim.id
+
+    redirect_to action: :code_form
+  end
+
+  def code_form
+    @claim = current_claim
+    redirect_to claim_path(@company) and return unless @claim
+  end
+
+  def confirm_code
+    @claim = current_claim
+    redirect_to claim_path(@company) and return unless @claim
+
+    code = params[:code].to_s.strip
+    unless @claim.verify_code(code)
+      redirect_to action: :code_form, alert: "Invalid or expired code." and return
+    end
+
+    @claim.approve_or_queue_review!
+
+    if @claim.review_status == "pending_review"
+      ProfileClaimMailer.admin_new_claim(@claim).deliver_later
+      redirect_to claim_path(@company), notice: "Verified — your claim is in admin review. We'll email you when it's approved." and return
+    end
+
+    @claim.update!(current_step: WIZARD_STEPS.first)
+    redirect_to claim_wizard_step_path(@company, WIZARD_STEPS.first)
+  end
+
+  def show_step
+    @step = params[:step]
+    redirect_to claim_path(@company) and return unless WIZARD_STEPS.include?(@step)
+  end
+
+  def update_step
+    @step = params[:step]
+    redirect_to claim_path(@company) and return unless WIZARD_STEPS.include?(@step)
+
+    case @step
+    when "basics" then update_basics
+    when "story"  then update_story
+    when "links"  then update_links
+    when "tags"   then update_tags_and_finalize
+    end
+  end
+
+  private
+
+  def set_company
+    @company = Company.find_by!(slug: params[:slug])
+  end
+
+  def reject_already_claimed!
+    return unless @company.claimed?
+    redirect_to company_path(@company), alert: "This listing has already been claimed."
+  end
+
+  def current_claim
+    return @current_claim if defined?(@current_claim)
+    cid = session[:profile_claim_id]
+    @current_claim = cid ? ProfileClaim.find_by(id: cid, company_id: @company.id) : nil
+  end
+
+  def set_claim_for_wizard
+    @claim = current_claim
+    if @claim.nil? || !@claim.approved?
+      redirect_to claim_path(@company), alert: "Please verify your email first."
+    end
+  end
+
+  def update_basics
+    @company.assign_attributes(params.expect(company: [ :tagline, :website, :city, :state, :founded_year ]))
+    save_step_or_render("basics", next_step: "story")
+  end
+
+  def update_story
+    @company.assign_attributes(params.expect(company: [ :description, :employee_count_bucket ]))
+    save_step_or_render("story", next_step: "links")
+  end
+
+  def update_links
+    @company.assign_attributes(params.expect(company: [ :linkedin_url, :github_url, :crunchbase_url, :twitter_url ]))
+    save_step_or_render("links", next_step: "tags")
+  end
+
+  def update_tags_and_finalize
+    tag_ids = Array(params[:tag_ids]).reject(&:blank?).map(&:to_i)
+    Company.transaction do
+      @company.tag_ids = tag_ids
+      @company.save!
+      finalize_claim!
+    end
+    redirect_to company_path(@company), notice: "Welcome aboard. #{@company.name} is now live."
+  rescue ActiveRecord::RecordInvalid => e
+    flash.now[:alert] = e.record.errors.full_messages.to_sentence
+    @step = "tags"
+    render :show_step, status: :unprocessable_entity
+  end
+
+  def save_step_or_render(step, next_step:)
+    if @company.save
+      @claim.update!(current_step: next_step)
+      redirect_to claim_wizard_step_path(@company, next_step)
+    else
+      flash.now[:alert] = @company.errors.full_messages.to_sentence
+      @step = step
+      render :show_step, status: :unprocessable_entity
+    end
+  end
+
+  def finalize_claim!
+    user = User.find_or_initialize_by(email: @claim.email)
+    user.role ||= "owner"
+    user.save!
+    @company.update!(
+      user: user,
+      claimed: true,
+      status: @company.status == "draft" ? "published" : @company.status,
+      last_verified_at: Time.current
+    )
+    @claim.update!(completed_at: Time.current, current_step: "done")
+    sign_in_as(user)
+    ProfileClaimMailer.welcome(user, @company).deliver_later
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,29 @@
+class SessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    user = User.find_by(email: params[:email].to_s.strip.downcase)
+    if user
+      SessionMailer.magic_link(user, user.magic_link_token).deliver_later
+    end
+    # Always render the same response — don't leak whether an email is registered.
+    render :sent
+  end
+
+  def verify
+    user = User.find_by_magic_link_token(params[:token])
+    if user
+      sign_in_as(user)
+      redirect_to(user.admin? ? admin_root_path : (user.company ? company_path(user.company) : root_path),
+                  notice: "Signed in.")
+    else
+      redirect_to sign_in_request_path, alert: "That sign-in link is invalid or expired."
+    end
+  end
+
+  def destroy
+    sign_out!
+    redirect_to root_path, notice: "Signed out."
+  end
+end

--- a/app/jobs/auto_reject_stale_pending_claims_job.rb
+++ b/app/jobs/auto_reject_stale_pending_claims_job.rb
@@ -1,0 +1,13 @@
+class AutoRejectStalePendingClaimsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    ProfileClaim.stale_pending.find_each do |claim|
+      claim.update!(
+        review_status: "rejected",
+        reviewed_by: "system:auto-reject",
+        reviewed_at: Time.current
+      )
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAIL_FROM", "Baltimore.ai <hello@baltimore.ai>")
   layout "mailer"
 end

--- a/app/mailers/profile_claim_mailer.rb
+++ b/app/mailers/profile_claim_mailer.rb
@@ -1,0 +1,33 @@
+class ProfileClaimMailer < ApplicationMailer
+  def verification_code(claim, code)
+    @claim = claim
+    @company = claim.company
+    @code = code
+    @ttl_minutes = ProfileClaim::VERIFICATION_CODE_TTL.in_minutes.to_i
+
+    mail(
+      to: claim.email,
+      subject: "Your Baltimore.ai verification code: #{code}"
+    )
+  end
+
+  def admin_new_claim(claim)
+    @claim = claim
+    @company = claim.company
+
+    mail(
+      to: ENV.fetch("ADMIN_EMAIL", "admin@baltimore.ai"),
+      subject: "[Baltimore.ai] Manual review needed: #{@company.name}"
+    )
+  end
+
+  def welcome(user, company)
+    @user = user
+    @company = company
+
+    mail(
+      to: user.email,
+      subject: "#{@company.name} is now live on Baltimore.ai"
+    )
+  end
+end

--- a/app/mailers/session_mailer.rb
+++ b/app/mailers/session_mailer.rb
@@ -1,0 +1,12 @@
+class SessionMailer < ApplicationMailer
+  def magic_link(user, token)
+    @user = user
+    @url = sign_in_url(token: token)
+    @ttl_minutes = User::MAGIC_LINK_TTL.in_minutes.to_i
+
+    mail(
+      to: user.email,
+      subject: "Sign in to Baltimore.ai"
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   ROLES = %w[owner admin].freeze
+  MAGIC_LINK_TTL = 15.minutes
+  SESSION_TTL = 30.days
 
-  has_secure_password
   has_one :company, dependent: :nullify
 
   validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP }
@@ -15,5 +16,21 @@ class User < ApplicationRecord
 
   def owner?
     role == "owner"
+  end
+
+  def magic_link_token
+    signed_id(purpose: :magic_link, expires_in: MAGIC_LINK_TTL)
+  end
+
+  def session_token
+    signed_id(purpose: :session, expires_in: SESSION_TTL)
+  end
+
+  def self.find_by_magic_link_token(token)
+    find_signed(token, purpose: :magic_link)
+  end
+
+  def self.find_by_session_token(token)
+    find_signed(token, purpose: :session)
   end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,24 @@
+<h1 class="text-2xl font-black mb-6">Dashboard</h1>
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+  <div class="bg-white p-4 rounded-md border border-stone-200">
+    <div class="text-xs uppercase tracking-wider text-stone-500">Pending review</div>
+    <div class="text-3xl font-black mt-1 <%= @pending_count > 0 ? 'text-red-700' : 'text-stone-900' %>"><%= @pending_count %></div>
+  </div>
+  <div class="bg-white p-4 rounded-md border border-stone-200">
+    <div class="text-xs uppercase tracking-wider text-stone-500">Stale (>30d)</div>
+    <div class="text-3xl font-black mt-1 <%= @stale_count > 0 ? 'text-amber-700' : 'text-stone-900' %>"><%= @stale_count %></div>
+  </div>
+  <div class="bg-white p-4 rounded-md border border-stone-200">
+    <div class="text-xs uppercase tracking-wider text-stone-500">Published</div>
+    <div class="text-3xl font-black mt-1"><%= @published_companies %> / <%= @total_companies %></div>
+  </div>
+  <div class="bg-white p-4 rounded-md border border-stone-200">
+    <div class="text-xs uppercase tracking-wider text-stone-500">Claimed</div>
+    <div class="text-3xl font-black mt-1"><%= @claimed_companies %></div>
+  </div>
+</div>
+
+<div class="bg-white p-4 rounded-md border border-stone-200">
+  <%= link_to "Review pending claims →", admin_profile_claims_path, class: "text-stone-900 font-semibold hover:text-red-700" %>
+</div>

--- a/app/views/admin/profile_claims/index.html.erb
+++ b/app/views/admin/profile_claims/index.html.erb
@@ -1,0 +1,51 @@
+<h1 class="text-2xl font-black mb-6">Claims</h1>
+
+<section class="mb-10">
+  <h2 class="text-xs uppercase tracking-wider text-stone-500 mb-3">Pending review (<%= @pending.size %>)</h2>
+  <% if @pending.any? %>
+    <div class="bg-white border border-stone-200 rounded-md overflow-hidden">
+      <% @pending.each do |claim| %>
+        <div class="p-4 border-b border-stone-100 last:border-0 flex flex-wrap items-baseline justify-between gap-3">
+          <div class="min-w-0">
+            <div class="font-semibold"><%= link_to claim.company.name, admin_profile_claim_path(claim), class: "hover:text-red-700" %></div>
+            <div class="text-sm text-stone-600">
+              <%= claim.claimant_name %> &lt;<%= claim.email %>&gt; · domain <strong><%= claim.email.split('@').last %></strong> vs site <strong><%= claim.company.domain %></strong>
+            </div>
+            <div class="text-xs text-stone-500 mt-1">Submitted <%= time_ago_in_words(claim.created_at) %> ago</div>
+          </div>
+          <div class="flex gap-2">
+            <%= button_to "Approve", approve_admin_profile_claim_path(claim), method: :post, class: "bg-emerald-700 text-white px-3 py-1.5 rounded text-sm hover:bg-emerald-800" %>
+            <%= button_to "Reject",  reject_admin_profile_claim_path(claim), method: :post, class: "bg-stone-200 text-stone-700 px-3 py-1.5 rounded text-sm hover:bg-stone-300", data: { turbo_confirm: "Reject this claim?" } %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="bg-white border border-stone-200 rounded-md p-6 text-stone-600 text-sm">Nothing in the queue.</div>
+  <% end %>
+</section>
+
+<section>
+  <h2 class="text-xs uppercase tracking-wider text-stone-500 mb-3">Recent activity</h2>
+  <div class="bg-white border border-stone-200 rounded-md overflow-hidden">
+    <% @recent.each do |claim| %>
+      <div class="p-3 border-b border-stone-100 last:border-0 flex items-baseline justify-between gap-3 text-sm">
+        <div>
+          <span class="font-semibold"><%= claim.company.name %></span>
+          <span class="text-stone-500"><%= claim.email %></span>
+        </div>
+        <div class="text-xs">
+          <span class="px-2 py-0.5 rounded
+            <%= case claim.review_status
+                when 'auto_approved', 'approved' then 'bg-emerald-50 text-emerald-700'
+                when 'rejected' then 'bg-stone-200 text-stone-700'
+                else 'bg-stone-100 text-stone-600'
+                end %>">
+            <%= claim.review_status %>
+          </span>
+          <span class="text-stone-500 ml-2"><%= time_ago_in_words(claim.updated_at) %> ago</span>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/admin/profile_claims/show.html.erb
+++ b/app/views/admin/profile_claims/show.html.erb
@@ -1,0 +1,38 @@
+<div class="mb-4 text-sm">
+  <%= link_to "← Back to claims", admin_profile_claims_path, class: "text-stone-600 hover:text-stone-900" %>
+</div>
+
+<h1 class="text-2xl font-black mb-2"><%= @claim.company.name %></h1>
+<p class="text-stone-600 mb-6">Claim by <strong><%= @claim.claimant_name %></strong> &lt;<%= @claim.email %>&gt;</p>
+
+<div class="grid md:grid-cols-2 gap-6">
+  <div class="bg-white border border-stone-200 rounded-md p-5">
+    <h2 class="text-xs uppercase tracking-wider text-stone-500 mb-3">Claim</h2>
+    <dl class="space-y-2 text-sm">
+      <div class="flex justify-between"><dt class="text-stone-500">Status</dt><dd class="font-semibold"><%= @claim.review_status %></dd></div>
+      <div class="flex justify-between"><dt class="text-stone-500">Method</dt><dd><%= @claim.verification_method || "—" %></dd></div>
+      <div class="flex justify-between"><dt class="text-stone-500">Verified at</dt><dd><%= @claim.verified_at&.strftime("%Y-%m-%d %H:%M") %></dd></div>
+      <div class="flex justify-between"><dt class="text-stone-500">Submitted</dt><dd><%= @claim.created_at.strftime("%Y-%m-%d %H:%M") %></dd></div>
+      <% if @claim.reviewed_by %>
+        <div class="flex justify-between"><dt class="text-stone-500">Reviewed by</dt><dd><%= @claim.reviewed_by %></dd></div>
+      <% end %>
+    </dl>
+  </div>
+  <div class="bg-white border border-stone-200 rounded-md p-5">
+    <h2 class="text-xs uppercase tracking-wider text-stone-500 mb-3">Company</h2>
+    <dl class="space-y-2 text-sm">
+      <div class="flex justify-between"><dt class="text-stone-500">Slug</dt><dd><%= link_to @claim.company.slug, company_path(@claim.company), class: "text-red-700 hover:underline", target: "_blank" %></dd></div>
+      <div class="flex justify-between"><dt class="text-stone-500">Website</dt><dd><%= @claim.company.website %></dd></div>
+      <div class="flex justify-between"><dt class="text-stone-500">Domain</dt><dd><%= @claim.company.domain %></dd></div>
+      <div class="flex justify-between"><dt class="text-stone-500">Email domain</dt><dd><%= @claim.email.split("@").last %></dd></div>
+      <div class="flex justify-between"><dt class="text-stone-500">Currently claimed?</dt><dd><%= @claim.company.claimed? ? "Yes" : "No" %></dd></div>
+    </dl>
+  </div>
+</div>
+
+<% if @claim.review_status == "pending_review" %>
+  <div class="mt-6 flex gap-3">
+    <%= button_to "Approve and publish", approve_admin_profile_claim_path(@claim), method: :post, class: "bg-emerald-700 text-white px-5 py-2.5 rounded-md font-semibold hover:bg-emerald-800" %>
+    <%= button_to "Reject", reject_admin_profile_claim_path(@claim), method: :post, class: "bg-stone-200 text-stone-700 px-5 py-2.5 rounded-md font-semibold hover:bg-stone-300", data: { turbo_confirm: "Reject this claim?" } %>
+  </div>
+<% end %>

--- a/app/views/companies/edit.html.erb
+++ b/app/views/companies/edit.html.erb
@@ -1,0 +1,86 @@
+<% content_for :title, page_title("Edit #{@company.name}") %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex,follow">
+<% end %>
+
+<div class="max-w-2xl mx-auto py-12">
+  <p class="text-xs uppercase tracking-[0.2em] text-red-700 font-semibold mb-3">Edit listing</p>
+  <h1 class="text-3xl md:text-4xl font-black tracking-tight mb-8"><%= @company.name %></h1>
+
+  <% if flash[:alert] %>
+    <div class="mb-4 p-3 bg-red-50 text-red-800 border border-red-200 rounded-md text-sm"><%= flash[:alert] %></div>
+  <% end %>
+
+  <%= form_with model: @company, url: company_path(@company), method: :patch, local: true, class: "space-y-5" do |f| %>
+    <div>
+      <%= f.label :tagline, "Tagline", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+      <%= f.text_field :tagline, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+    </div>
+    <div>
+      <%= f.label :description, "Description", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+      <%= f.text_area :description, rows: 8, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+    </div>
+    <div>
+      <%= f.label :website, "Website", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+      <%= f.url_field :website, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+    </div>
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <%= f.label :linkedin_url, "LinkedIn", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :linkedin_url, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :github_url, "GitHub", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :github_url, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :crunchbase_url, "Crunchbase", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :crunchbase_url, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :twitter_url, "X / Twitter", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :twitter_url, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+    </div>
+    <div class="grid grid-cols-3 gap-4">
+      <div>
+        <%= f.label :city, class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.text_field :city, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :state, class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.text_field :state, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :founded_year, "Founded", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.number_field :founded_year, min: 1900, max: Date.current.year, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+    </div>
+
+    <div>
+      <%= f.label :employee_count_bucket, "Team size", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+      <%= f.select :employee_count_bucket,
+            [ [ "Just me", "1" ], [ "2-10", "2-10" ], [ "11-50", "11-50" ], [ "51-200", "51-200" ], [ "201-500", "201-500" ], [ "501-1000", "501-1000" ], [ "1000+", "1000+" ] ],
+            { include_blank: "Choose..." },
+            class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+    </div>
+
+    <div>
+      <p class="block text-sm font-semibold text-stone-700 mb-2">Tags</p>
+      <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
+        <% Tag.order(:name).each do |tag| %>
+          <label class="flex items-center gap-2 p-2 border border-stone-200 rounded-md hover:bg-stone-50 cursor-pointer">
+            <%= check_box_tag "tag_ids[]", tag.id, @company.tag_ids.include?(tag.id),
+                  class: "h-4 w-4 text-stone-900 border-stone-300 rounded" %>
+            <span class="text-sm"><%= tag.name %></span>
+          </label>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-between pt-6 border-t border-stone-200">
+      <%= link_to "Cancel", company_path(@company), class: "text-stone-600 hover:text-stone-900 text-sm" %>
+      <%= f.submit "Save changes", class: "bg-stone-900 text-white px-5 py-2.5 rounded-md font-semibold hover:bg-stone-700" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -19,9 +19,13 @@
         <% end %>
       </div>
       <% if @company.claimed? %>
-        <span class="text-xs uppercase tracking-wider px-2 py-1 bg-emerald-50 text-emerald-700 border border-emerald-200 rounded">Claimed</span>
+        <% if signed_in? && current_user.company == @company %>
+          <%= link_to "Edit your listing →", edit_company_path(@company), class: "text-xs uppercase tracking-wider px-3 py-1.5 bg-stone-900 text-white rounded hover:bg-stone-700" %>
+        <% else %>
+          <span class="text-xs uppercase tracking-wider px-2 py-1 bg-emerald-50 text-emerald-700 border border-emerald-200 rounded">Claimed</span>
+        <% end %>
       <% else %>
-        <span class="text-xs uppercase tracking-wider px-2 py-1 bg-stone-50 text-stone-600 border border-stone-200 rounded">Unclaimed</span>
+        <%= link_to "Claim this listing →", claim_path(@company), class: "text-xs uppercase tracking-wider px-3 py-1.5 bg-red-700 text-white rounded hover:bg-red-800" %>
       <% end %>
     </div>
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Admin · Baltimore.ai</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="robots" content="noindex,nofollow">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+  <body class="bg-stone-100 text-stone-900 antialiased font-sans min-h-screen">
+    <header class="bg-stone-900 text-stone-100 border-b border-stone-700">
+      <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+        <div class="flex items-center gap-6">
+          <%= link_to admin_root_path, class: "font-black tracking-tight" do %>
+            baltimore<span class="text-red-500">.ai</span> <span class="text-stone-400 text-sm font-normal">/ admin</span>
+          <% end %>
+          <nav class="flex gap-4 text-sm text-stone-300">
+            <%= link_to "Dashboard", admin_root_path, class: "hover:text-white" %>
+            <%= link_to "Claims", admin_profile_claims_path, class: "hover:text-white" %>
+          </nav>
+        </div>
+        <div class="text-sm text-stone-300">
+          <%= current_user&.email %> ·
+          <%= button_to "Sign out", sign_out_path, method: :delete, class: "underline hover:text-white", form_class: "inline" %>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-6xl mx-auto px-6 py-8">
+      <% if flash[:notice] %>
+        <div class="mb-4 p-3 bg-emerald-50 text-emerald-800 border border-emerald-200 rounded-md text-sm"><%= flash[:notice] %></div>
+      <% end %>
+      <% if flash[:alert] %>
+        <div class="mb-4 p-3 bg-red-50 text-red-800 border border-red-200 rounded-md text-sm"><%= flash[:alert] %></div>
+      <% end %>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/app/views/profile_claim_mailer/admin_new_claim.html.erb
+++ b/app/views/profile_claim_mailer/admin_new_claim.html.erb
@@ -1,0 +1,13 @@
+<div style="font-family: -apple-system, sans-serif; max-width: 520px; padding: 24px;">
+  <h1 style="margin: 0 0 16px; font-size: 18px;">Manual review needed</h1>
+  <table style="width: 100%; border-collapse: collapse; font-size: 14px;">
+    <tr><td style="padding: 6px 0; color: #78716c; width: 110px;">Company</td><td style="padding: 6px 0;"><strong><%= @company.name %></strong></td></tr>
+    <tr><td style="padding: 6px 0; color: #78716c;">Website</td><td style="padding: 6px 0;"><%= @company.website %></td></tr>
+    <tr><td style="padding: 6px 0; color: #78716c;">Claimant</td><td style="padding: 6px 0;"><%= @claim.claimant_name %></td></tr>
+    <tr><td style="padding: 6px 0; color: #78716c;">Email</td><td style="padding: 6px 0;"><%= @claim.email %></td></tr>
+    <tr><td style="padding: 6px 0; color: #78716c;">Domain match</td><td style="padding: 6px 0; color: #b91c1c;">No</td></tr>
+  </table>
+  <p style="margin-top: 24px;">
+    <a href="<%= admin_profile_claims_url %>" style="display: inline-block; background: #1c1917; color: white; padding: 10px 16px; text-decoration: none; border-radius: 4px; font-size: 14px;">Review queue</a>
+  </p>
+</div>

--- a/app/views/profile_claim_mailer/admin_new_claim.text.erb
+++ b/app/views/profile_claim_mailer/admin_new_claim.text.erb
@@ -1,0 +1,8 @@
+A new claim is pending manual review.
+
+Company: <%= @company.name %>
+Listing: <%= @company.website %>
+Claimant: <%= @claim.claimant_name %> <<%= @claim.email %>>
+Domain match: NO
+
+Review at: <%= admin_profile_claims_url %>

--- a/app/views/profile_claim_mailer/verification_code.html.erb
+++ b/app/views/profile_claim_mailer/verification_code.html.erb
@@ -1,0 +1,11 @@
+<div style="font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif; max-width: 480px; margin: 0 auto; padding: 24px; color: #1c1917;">
+  <p style="margin: 0 0 8px; font-size: 14px; color: #78716c;">Your Baltimore.ai verification code:</p>
+  <p style="margin: 0 0 24px; font-size: 36px; font-weight: 800; letter-spacing: 0.1em; color: #b91c1c;"><%= @code %></p>
+  <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5;">
+    Enter this on the claim page to verify ownership of <strong><%= @company.name %></strong>.
+  </p>
+  <p style="margin: 0 0 16px; font-size: 14px; color: #78716c;">
+    This code expires in <%= @ttl_minutes %> minutes. If you didn't request it, you can ignore this email.
+  </p>
+  <p style="margin: 24px 0 0; font-size: 13px; color: #a8a29e;">— Baltimore.ai</p>
+</div>

--- a/app/views/profile_claim_mailer/verification_code.text.erb
+++ b/app/views/profile_claim_mailer/verification_code.text.erb
@@ -1,0 +1,9 @@
+Your Baltimore.ai verification code:
+
+  <%= @code %>
+
+Enter this on the claim page to verify ownership of <%= @company.name %>.
+
+This code expires in <%= @ttl_minutes %> minutes. If you didn't request it, you can ignore this email.
+
+— Baltimore.ai

--- a/app/views/profile_claim_mailer/welcome.html.erb
+++ b/app/views/profile_claim_mailer/welcome.html.erb
@@ -1,0 +1,10 @@
+<div style="font-family: -apple-system, sans-serif; max-width: 480px; padding: 24px; color: #1c1917;">
+  <p style="margin: 0 0 16px; font-size: 16px;"><strong><%= @company.name %></strong> is now live on Baltimore.ai.</p>
+  <p style="margin: 0 0 24px;">
+    <a href="<%= company_url(@company) %>" style="display: inline-block; background: #b91c1c; color: white; padding: 10px 16px; text-decoration: none; border-radius: 4px; font-size: 14px;">View your listing</a>
+  </p>
+  <p style="margin: 0 0 16px; font-size: 14px; color: #57534e;">
+    To edit it later, request a sign-in link at <a href="<%= sign_in_request_url %>"><%= sign_in_request_url %></a> using <strong><%= @user.email %></strong>.
+  </p>
+  <p style="margin: 24px 0 0; font-size: 13px; color: #a8a29e;">— Baltimore.ai</p>
+</div>

--- a/app/views/profile_claim_mailer/welcome.text.erb
+++ b/app/views/profile_claim_mailer/welcome.text.erb
@@ -1,0 +1,9 @@
+<%= @company.name %> is now live on Baltimore.ai.
+
+View your listing: <%= company_url(@company) %>
+
+To edit it later, request a sign-in link at <%= sign_in_request_url %> using <%= @user.email %>.
+
+Thanks for being part of Baltimore's AI scene.
+
+— Baltimore.ai

--- a/app/views/profile_claims/_step_indicator.html.erb
+++ b/app/views/profile_claims/_step_indicator.html.erb
@@ -1,0 +1,15 @@
+<%# locals: (current:, steps: ProfileClaimsController::WIZARD_STEPS) %>
+<ol class="flex items-center gap-2 text-xs uppercase tracking-wider text-stone-500 mb-8">
+  <% steps.each_with_index do |step, i| %>
+    <% active = step == current %>
+    <% done   = steps.index(current) > i %>
+    <li class="flex items-center gap-2">
+      <span class="<%= active ? 'text-stone-900 font-semibold' : (done ? 'text-stone-700' : '') %>">
+        <%= i + 1 %>. <%= step %>
+      </span>
+      <% if i < steps.length - 1 %>
+        <span aria-hidden="true">/</span>
+      <% end %>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/profile_claims/code_form.html.erb
+++ b/app/views/profile_claims/code_form.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, page_title("Verify your email") %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex,follow">
+<% end %>
+
+<div class="max-w-md mx-auto py-12">
+  <p class="text-xs uppercase tracking-[0.2em] text-red-700 font-semibold mb-3">Verify</p>
+  <h1 class="text-3xl font-black tracking-tight mb-3">Enter the 6-digit code</h1>
+  <p class="text-stone-600 mb-8">We emailed a code to <strong><%= @claim.email %></strong>. It expires in 15 minutes.</p>
+
+  <% if flash[:alert] %>
+    <div class="mb-4 p-3 bg-red-50 text-red-800 border border-red-200 rounded-md text-sm"><%= flash[:alert] %></div>
+  <% end %>
+
+  <%= form_with url: url_for(action: :confirm_code), method: :post, local: true, class: "space-y-4" do |f| %>
+    <%= f.label :code, "Verification code", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+    <%= f.text_field :code, required: true, autofocus: true, autocomplete: "one-time-code",
+          inputmode: "numeric", pattern: "[0-9]*", maxlength: 6,
+          class: "w-full px-3 py-2 border border-stone-300 rounded-md focus:border-stone-900 focus:outline-none text-2xl tracking-[0.3em] text-center font-mono" %>
+    <%= f.submit "Verify",
+          class: "w-full bg-stone-900 text-white px-4 py-2.5 rounded-md font-semibold hover:bg-stone-700" %>
+  <% end %>
+
+  <p class="text-stone-500 text-sm mt-6 text-center">
+    Didn't get it? <%= link_to "Try again", claim_path(@company), class: "underline hover:text-stone-900" %>
+  </p>
+</div>

--- a/app/views/profile_claims/show_step.html.erb
+++ b/app/views/profile_claims/show_step.html.erb
@@ -1,0 +1,99 @@
+<% content_for :title, page_title("Claim #{@company.name}: #{@step}") %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex,follow">
+<% end %>
+
+<div class="max-w-2xl mx-auto py-12">
+  <%= render "step_indicator", current: @step %>
+
+  <h1 class="text-3xl md:text-4xl font-black tracking-tight mb-2"><%= @company.name %></h1>
+
+  <% if flash[:alert] %>
+    <div class="mb-4 p-3 bg-red-50 text-red-800 border border-red-200 rounded-md text-sm"><%= flash[:alert] %></div>
+  <% end %>
+
+  <%= form_with model: @company, url: claim_wizard_step_path(@company, @step), method: :patch, local: true, class: "space-y-5 mt-6" do |f| %>
+    <% case @step %>
+    <% when "basics" %>
+      <p class="text-stone-600">The essentials. We'll show this in your listing's header.</p>
+      <div>
+        <%= f.label :tagline, "One-line tagline", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.text_field :tagline, class: "w-full px-3 py-2 border border-stone-300 rounded-md", placeholder: "AI-powered ___ for ___" %>
+      </div>
+      <div>
+        <%= f.label :website, "Website", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :website, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <%= f.label :city, class: "block text-sm font-semibold text-stone-700 mb-1" %>
+          <%= f.text_field :city, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+        </div>
+        <div>
+          <%= f.label :state, class: "block text-sm font-semibold text-stone-700 mb-1" %>
+          <%= f.text_field :state, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+        </div>
+      </div>
+      <div>
+        <%= f.label :founded_year, "Founded", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.number_field :founded_year, min: 1900, max: Date.current.year, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+
+    <% when "story" %>
+      <p class="text-stone-600">What does <%= @company.name %> do? A few sentences. This is the most-read part of your listing.</p>
+      <div>
+        <%= f.label :description, "Description", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.text_area :description, rows: 8, class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :employee_count_bucket, "Team size", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.select :employee_count_bucket,
+              [ [ "Just me", "1" ], [ "2-10", "2-10" ], [ "11-50", "11-50" ], [ "51-200", "51-200" ], [ "201-500", "201-500" ], [ "501-1000", "501-1000" ], [ "1000+", "1000+" ] ],
+              { include_blank: "Choose..." },
+              class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+
+    <% when "links" %>
+      <p class="text-stone-600">Public profiles. Each one strengthens your listing's SEO and credibility.</p>
+      <div>
+        <%= f.label :linkedin_url, "LinkedIn", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :linkedin_url, placeholder: "https://linkedin.com/company/...", class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :github_url, "GitHub", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :github_url, placeholder: "https://github.com/...", class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :crunchbase_url, "Crunchbase", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :crunchbase_url, placeholder: "https://crunchbase.com/organization/...", class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+      <div>
+        <%= f.label :twitter_url, "X / Twitter", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+        <%= f.url_field :twitter_url, placeholder: "https://x.com/...", class: "w-full px-3 py-2 border border-stone-300 rounded-md" %>
+      </div>
+
+    <% when "tags" %>
+      <p class="text-stone-600">Pick the tags that describe your work. Choose 1–5.</p>
+      <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
+        <% Tag.order(:name).each do |tag| %>
+          <label class="flex items-center gap-2 p-2 border border-stone-200 rounded-md hover:bg-stone-50 cursor-pointer">
+            <%= check_box_tag "tag_ids[]", tag.id, @company.tag_ids.include?(tag.id),
+                  class: "h-4 w-4 text-stone-900 border-stone-300 rounded" %>
+            <span class="text-sm"><%= tag.name %></span>
+          </label>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="flex items-center justify-between pt-6 border-t border-stone-200">
+      <% prev_step = ProfileClaimsController::WIZARD_STEPS[ProfileClaimsController::WIZARD_STEPS.index(@step) - 1] if ProfileClaimsController::WIZARD_STEPS.index(@step) > 0 %>
+      <% if prev_step %>
+        <%= link_to "← Back", claim_wizard_step_path(@company, prev_step), class: "text-stone-600 hover:text-stone-900 text-sm" %>
+      <% else %>
+        <span></span>
+      <% end %>
+      <%= f.submit @step == "tags" ? "Publish listing →" : "Save & continue →",
+            class: "bg-stone-900 text-white px-5 py-2.5 rounded-md font-semibold hover:bg-stone-700" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/profile_claims/start.html.erb
+++ b/app/views/profile_claims/start.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title, page_title("Claim #{@company.name}") %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex,follow">
+<% end %>
+
+<div class="max-w-lg mx-auto py-12">
+  <p class="text-xs uppercase tracking-[0.2em] text-red-700 font-semibold mb-3">Claim a listing</p>
+  <h1 class="text-3xl md:text-4xl font-black tracking-tight mb-3"><%= @company.name %></h1>
+  <p class="text-stone-600 mb-8">
+    Claim this listing to edit it, add details, and keep it accurate. We'll email a verification code to confirm you work at <%= @company.name %>.
+  </p>
+
+  <% if flash[:alert] %>
+    <div class="mb-4 p-3 bg-red-50 text-red-800 border border-red-200 rounded-md text-sm"><%= flash[:alert] %></div>
+  <% end %>
+
+  <%= form_with url: url_for(action: :send_code), method: :post, local: true, class: "space-y-4" do |f| %>
+    <div>
+      <%= f.label :claimant_name, "Your name", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+      <%= f.text_field :claimant_name, required: true, class: "w-full px-3 py-2 border border-stone-300 rounded-md focus:border-stone-900 focus:outline-none" %>
+    </div>
+    <div>
+      <%= f.label :email, "Work email", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+      <%= f.email_field :email, required: true, autocomplete: "email", placeholder: "you@#{@company.domain || 'yourcompany.com'}",
+            class: "w-full px-3 py-2 border border-stone-300 rounded-md focus:border-stone-900 focus:outline-none" %>
+      <p class="text-xs text-stone-500 mt-1">Best to use an email at the same domain as <%= @company.domain || 'the company website' %> — that auto-approves.</p>
+    </div>
+    <%= f.submit "Send verification code",
+          class: "w-full bg-stone-900 text-white px-4 py-2.5 rounded-md font-semibold hover:bg-stone-700" %>
+  <% end %>
+</div>

--- a/app/views/session_mailer/magic_link.html.erb
+++ b/app/views/session_mailer/magic_link.html.erb
@@ -1,0 +1,13 @@
+<div style="font-family: -apple-system, sans-serif; max-width: 480px; padding: 24px; color: #1c1917;">
+  <p style="margin: 0 0 16px; font-size: 16px;">Click below to sign in to Baltimore.ai:</p>
+  <p style="margin: 0 0 24px;">
+    <a href="<%= @url %>" style="display: inline-block; background: #b91c1c; color: white; padding: 10px 16px; text-decoration: none; border-radius: 4px; font-size: 14px;">Sign in</a>
+  </p>
+  <p style="margin: 0 0 16px; font-size: 13px; color: #78716c; word-break: break-all;">
+    Or copy this link: <%= @url %>
+  </p>
+  <p style="margin: 0 0 16px; font-size: 14px; color: #57534e;">
+    This link expires in <%= @ttl_minutes %> minutes. If you didn't request it, you can ignore this email.
+  </p>
+  <p style="margin: 24px 0 0; font-size: 13px; color: #a8a29e;">— Baltimore.ai</p>
+</div>

--- a/app/views/session_mailer/magic_link.text.erb
+++ b/app/views/session_mailer/magic_link.text.erb
@@ -1,0 +1,7 @@
+Sign in to Baltimore.ai:
+
+<%= @url %>
+
+This link expires in <%= @ttl_minutes %> minutes. If you didn't request it, you can ignore this email.
+
+— Baltimore.ai

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, page_title("Sign in") %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex,follow">
+<% end %>
+
+<div class="max-w-md mx-auto py-12">
+  <h1 class="text-3xl font-black tracking-tight mb-2">Sign in</h1>
+  <p class="text-stone-600 mb-8">We'll email you a one-time link. No password needed.</p>
+
+  <%= form_with url: sign_in_request_path, method: :post, local: true, class: "space-y-4" do |f| %>
+    <div>
+      <%= f.label :email, "Email", class: "block text-sm font-semibold text-stone-700 mb-1" %>
+      <%= f.email_field :email, required: true, autofocus: true, autocomplete: "email",
+            class: "w-full px-3 py-2 border border-stone-300 rounded-md focus:border-stone-900 focus:outline-none" %>
+    </div>
+    <%= f.submit "Email me a sign-in link",
+          class: "w-full bg-stone-900 text-white px-4 py-2.5 rounded-md font-semibold hover:bg-stone-700" %>
+  <% end %>
+</div>

--- a/app/views/sessions/sent.html.erb
+++ b/app/views/sessions/sent.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, page_title("Check your email") %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex,follow">
+<% end %>
+
+<div class="max-w-md mx-auto py-12 text-center">
+  <h1 class="text-3xl font-black tracking-tight mb-3">Check your email</h1>
+  <p class="text-stone-600">If an account exists for that address, we just sent a sign-in link. It expires in 15 minutes.</p>
+  <p class="text-stone-500 text-sm mt-6">
+    <%= link_to "Try a different email", sign_in_request_path, class: "underline hover:text-stone-900" %>
+  </p>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,10 @@ Rails.application.configure do
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+  # Preview mail in the browser via letter_opener instead of sending.
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Run jobs (and thus deliver_later mail) inline in tests.
+  config.active_job.queue_adapter = :inline
+
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "example.com" }
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,6 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  auto_reject_stale_pending_claims:
+    class: AutoRejectStalePendingClaimsJob
+    schedule: every day at 03:00

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,39 @@
 Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
-  resources :companies, only: [ :index, :show ], param: :slug
+  # Public directory
+  resources :companies, only: [ :index, :show, :edit, :update ], param: :slug
   resources :categories, only: [ :index, :show ], param: :slug
   resources :resources, only: [ :index, :show ], param: :slug
 
+  # Sessions (magic link auth)
+  get    "sign-in",         to: "sessions#new",     as: :sign_in_request
+  post   "sign-in",         to: "sessions#create",  as: :send_magic_link
+  get    "sign-in/verify",  to: "sessions#verify",  as: :sign_in
+  delete "sign-out",        to: "sessions#destroy", as: :sign_out
+
+  # Claim flow
+  scope "/claim/:slug", controller: "profile_claims" do
+    get  "/",         action: :start,    as: :claim
+    post "verify",    action: :send_code
+    get  "code",      action: :code_form
+    post "code",      action: :confirm_code
+    get  "wizard/:step", action: :show_step,   as: :claim_wizard_step
+    patch "wizard/:step", action: :update_step
+  end
+
+  # Admin
+  namespace :admin do
+    root to: "dashboard#index"
+    resources :profile_claims, only: [ :index, :show ] do
+      member do
+        post :approve
+        post :reject
+      end
+    end
+  end
+
+  # Static
   get "robots", to: "static#robots", defaults: { format: "txt" }
 
   root "home#index"

--- a/db/migrate/20260506153442_remove_password_digest_from_users.rb
+++ b/db/migrate/20260506153442_remove_password_digest_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordDigestFromUsers < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_132349) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_153442) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -112,7 +112,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_132349) do
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", null: false
-    t.string "password_digest", null: false
     t.string "role", default: "owner", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,15 @@
 # Editorial blurbs are unique per entry to satisfy Google's thin-content threshold.
 # Run with: bin/rails db:seed
 
+puts "Seeding admin user..."
+
+if (admin_email = ENV["ADMIN_EMAIL"]).present?
+  admin = User.find_or_initialize_by(email: admin_email)
+  admin.role = "admin"
+  admin.save!
+  puts "  -> admin user: #{admin.email}"
+end
+
 puts "Seeding tags..."
 
 TAGS = {

--- a/test/integration/claim_flow_test.rb
+++ b/test/integration/claim_flow_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class ClaimFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    @company = Company.create!(
+      name: "Acme AI",
+      primary_category: "applied_ai",
+      website: "https://acme-ai.example",
+      status: "published"
+    )
+  end
+
+  test "scenario 1: domain-match auto-approves end-to-end" do
+    assert_emails 1 do
+      post "/claim/#{@company.slug}/verify",
+           params: { email: "founder@acme-ai.example", claimant_name: "Jamie" }
+    end
+    follow_redirect!
+
+    code = extract_code_from_last_email
+    post "/claim/#{@company.slug}/code", params: { code: code }
+    assert_redirected_to "/claim/#{@company.slug}/wizard/basics"
+
+    claim = ProfileClaim.last
+    assert_equal "auto_approved", claim.review_status
+    assert_equal "domain_match",  claim.verification_method
+
+    # Walk the wizard
+    patch "/claim/#{@company.slug}/wizard/basics",
+          params: { company: { tagline: "We do AI", website: @company.website, city: "Baltimore", state: "MD", founded_year: 2024 } }
+    assert_redirected_to "/claim/#{@company.slug}/wizard/story"
+
+    patch "/claim/#{@company.slug}/wizard/story",
+          params: { company: { description: "Acme AI does cool things.", employee_count_bucket: "11-50" } }
+    assert_redirected_to "/claim/#{@company.slug}/wizard/links"
+
+    patch "/claim/#{@company.slug}/wizard/links",
+          params: { company: { linkedin_url: "https://linkedin.com/company/acme-ai" } }
+    assert_redirected_to "/claim/#{@company.slug}/wizard/tags"
+
+    patch "/claim/#{@company.slug}/wizard/tags", params: { tag_ids: [] }
+    assert_redirected_to "/companies/#{@company.slug}"
+
+    @company.reload
+    assert @company.claimed?, "company should be marked claimed"
+    assert @company.user.present?, "company should have an owner"
+    assert_equal "founder@acme-ai.example", @company.user.email
+  end
+
+  test "scenario 2: non-domain-match goes to admin queue" do
+    post "/claim/#{@company.slug}/verify",
+         params: { email: "different@gmail.com", claimant_name: "Jamie" }
+    follow_redirect!
+
+    code = extract_code_from_last_email
+    assert_emails 1 do  # admin notification
+      post "/claim/#{@company.slug}/code", params: { code: code }
+    end
+
+    claim = ProfileClaim.last
+    assert_equal "manual_review", claim.verification_method
+    assert_equal "pending_review", claim.review_status
+    assert_not @company.reload.claimed?, "company should NOT be claimed yet"
+  end
+
+  test "scenario 3: claim is blocked when company is already claimed" do
+    @company.update!(claimed: true)
+    post "/claim/#{@company.slug}/verify",
+         params: { email: "anyone@acme-ai.example", claimant_name: "Late" }
+    assert_redirected_to "/companies/#{@company.slug}"
+    follow_redirect!
+    assert_match(/already been claimed/i, flash[:alert].to_s)
+  end
+
+  test "scenario 4: rate-limit blocks rapid resends within cooldown" do
+    post "/claim/#{@company.slug}/verify",
+         params: { email: "founder@acme-ai.example", claimant_name: "Jamie" }
+    follow_redirect!  # consume first redirect
+
+    post "/claim/#{@company.slug}/verify",
+         params: { email: "founder@acme-ai.example", claimant_name: "Jamie" }
+    assert_redirected_to "/claim/#{@company.slug}"
+    follow_redirect!
+    assert_match(/Slow down/i, flash[:alert].to_s)
+  end
+
+  test "scenario 5: wizard is blocked without a verified claim in session" do
+    get "/claim/#{@company.slug}/wizard/basics"
+    assert_redirected_to "/claim/#{@company.slug}"
+    follow_redirect!
+    assert_match(/verify your email/i, flash[:alert].to_s)
+  end
+
+  private
+
+  def extract_code_from_last_email
+    body = ActionMailer::Base.deliveries.last.text_part.body.to_s
+    body.match(/(\d{6})/)[1]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,7 @@
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+require "rails/test_help"
+
+class ActiveSupport::TestCase
+  parallelize(workers: 1)
+end


### PR DESCRIPTION
## Summary

Ships Phase 3 of the [MVP plan](docs/plans/2026-05-05-feat-baltimore-ai-directory-mvp-plan.md). Listings can now be claimed self-serve.

**Claim flow:**
- `GET /claim/:slug` → email entry → 6-digit code → 4-step wizard (basics → story → links → tags) → publish
- Domain-match (claimant email domain == company website domain) auto-approves
- Non-match goes to `/admin/profile_claims` for manual review
- Rate-limited per RooferRate pattern (60s cooldown, 3/hour cap)
- 15-minute code TTL, BCrypt-hashed in DB

**Auth (magic links, no passwords):**
- `User#magic_link_token` / `User#session_token` via Rails `signed_id`
- Cookie-based session, 30-day TTL
- `current_user`, `signed_in?`, `require_admin!` helpers in `ApplicationController`
- Owner edit gated by `current_user.company == @company`

**Admin:**
- Separate layout (`noindex`)
- Dashboard with pending/stale/published/claimed counts
- Profile claims index/show/approve/reject with audit trail (`reviewed_by`, `reviewed_at`)
- `AutoRejectStalePendingClaimsJob` recurring daily at 03:00 (rejects claims pending >30d)

**Tests:**
- 5/5 integration scenarios from the plan, 42 assertions, all green
- Switched test queue adapter to `:inline` so `deliver_later` runs synchronously
- New `test` CI job with Postgres service

**Mailers:**
- `ProfileClaimMailer` (verification_code, admin_new_claim, welcome)
- `SessionMailer` (magic_link)
- `letter_opener` for dev preview

## Verification

- [x] All 5 plan scenarios covered by integration tests
- [x] Rubocop clean
- [x] Visual smoke check on /claim/redshred (screenshot in conversation)
- [x] All public routes still 200

## Honest flags

- **No production smoke test of email delivery** — mailer config defaults to `letter_opener` in dev, `:test` in test. Production needs `SMTP_*` env vars + Postmark/Resend. Documented in DEPLOY.md follow-up.
- **`AutoRejectStalePendingClaimsJob` runs only in production** — `recurring.yml` only loads under `production:`. Manual run via `bin/jobs` works in dev.
- **Magic link tokens leak via referer if owner clicks an outbound link in a sent email** — standard concern. Mitigation: short TTL (15 min) and one-time-style handling at `:verify` (we don't enforce single-use yet — could add a nonce table later).

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs: search `ProfileClaim` events, `SessionMailer#magic_link`, mailer delivery errors
  - Queue: Solid Queue dashboard for failed mail jobs (especially `verification_code` and `magic_link`)
- **Validation queries**
  - `Company.where(claimed: true).count` — should be 0 at deploy, grow with usage
  - `ProfileClaim.pending_review.count` — admin queue depth, watch for growth
  - `ProfileClaim.where(verification_method: nil).where("created_at > ?", 1.hour.ago).count` — abandoned claims (people who didn't enter the code)
- **Expected healthy behavior**
  - Verification emails arrive in <30s
  - Domain-matched claims complete the wizard in <5 min
  - Admin queue size remains <20
- **Failure signals**
  - Mailer error rate >1% → check SMTP creds, fallback to alternate provider
  - Queue length on `mailers` queue persistently >50 → scale worker or investigate bounces
  - Any spike in `pending_review` → spam attempt; tighten rate limit
- **Rollback**
  - `fly deploy --image <prior>` → reverts code, claim records persist
- **Validation window & owner**
  - 7 days post-deploy, owner: @justuseapen

## Plan

[docs/plans/2026-05-05-feat-baltimore-ai-directory-mvp-plan.md](docs/plans/2026-05-05-feat-baltimore-ai-directory-mvp-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)