### PR TITLE
Phase 4: editorial guides + Postmark + FAQPage + launch prep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem "bcrypt", "~> 3.1.7"
 # Sitemap generation for SEO [https://github.com/kjvarga/sitemap_generator]
 gem "sitemap_generator"
 
+# Markdown rendering for editorial guides [https://github.com/gjtorikian/commonmarker]
+gem "commonmarker"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,12 @@ GEM
       thor (~> 1.0)
     childprocess (5.1.0)
       logger (~> 1.5)
+    commonmarker (2.8.1-aarch64-linux)
+    commonmarker (2.8.1-aarch64-linux-musl)
+    commonmarker (2.8.1-arm-linux)
+    commonmarker (2.8.1-arm64-darwin)
+    commonmarker (2.8.1-x86_64-linux)
+    commonmarker (2.8.1-x86_64-linux-musl)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -388,6 +394,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bundler-audit
+  commonmarker
   debug
   image_processing (~> 1.2)
   importmap-rails

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,57 @@
 @import "tailwindcss";
+
+/* Editorial prose — used on /guides/:slug. Custom because tailwindcss-rails
+   ships standalone (no npm), so adding @tailwindcss/typography is more
+   trouble than writing a few rules. */
+.prose-editorial {
+  color: #1c1917;
+  line-height: 1.75;
+}
+.prose-editorial > * + * { margin-top: 1.25em; }
+.prose-editorial h2 {
+  font-size: 1.75rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-top: 2.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.2;
+}
+.prose-editorial h3 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-top: 2em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+.prose-editorial p { font-size: 1.0625rem; }
+.prose-editorial a {
+  color: #b91c1c;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(185, 28, 28, 0.25);
+}
+.prose-editorial a:hover { border-bottom-color: #b91c1c; }
+.prose-editorial strong { color: #0c0a09; font-weight: 600; }
+.prose-editorial ul, .prose-editorial ol {
+  padding-left: 1.5em;
+}
+.prose-editorial ul { list-style: disc; }
+.prose-editorial ol { list-style: decimal; }
+.prose-editorial li + li { margin-top: 0.5em; }
+.prose-editorial blockquote {
+  border-left: 3px solid #e7e5e4;
+  padding-left: 1em;
+  font-style: italic;
+  color: #44403c;
+}
+.prose-editorial code {
+  background: #f5f5f4;
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+.prose-editorial hr {
+  border: 0;
+  border-top: 1px solid #e7e5e4;
+  margin: 2em 0;
+}

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -1,0 +1,10 @@
+class GuidesController < ApplicationController
+  def index
+    @guides = Guide.published.order(published_at: :desc)
+  end
+
+  def show
+    @guide = Guide.published.find_by!(slug: params[:slug])
+    @related = Guide.published.where.not(id: @guide.id).order(published_at: :desc).limit(3)
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,5 +4,6 @@ class HomeController < ApplicationController
     @category_counts = Company.published.group(:primary_category).count
     @resources = Resource.published.order(name: :asc).limit(6)
     @total_companies = Company.published.count
+    @guides = Guide.published.order(published_at: :desc).limit(3)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,4 +31,9 @@ module ApplicationHelper
   def page_title(*parts)
     parts.compact.push("Baltimore.ai").join(" · ")
   end
+
+  def render_markdown(text)
+    return "" if text.blank?
+    sanitize(Commonmarker.to_html(text, options: { extension: { table: true, strikethrough: true, autolink: true } }))
+  end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,0 +1,22 @@
+class Guide < ApplicationRecord
+  STATUSES = %w[draft published hidden].freeze
+
+  validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z/ }
+  validates :title, presence: true
+  validates :body, presence: true
+  validates :status, inclusion: { in: STATUSES }
+
+  before_validation :generate_slug, on: :create
+
+  scope :published, -> { where(status: "published").where.not(published_at: nil) }
+
+  def to_param
+    slug
+  end
+
+  private
+
+  def generate_slug
+    self.slug = title.to_s.parameterize if slug.blank? && title.present?
+  end
+end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -31,3 +31,46 @@
     No companies listed in this category yet. <%= link_to "Browse all companies", companies_path, class: "text-red-700 hover:underline" %>.
   </div>
 <% end %>
+
+<% if @companies.any? %>
+  <% label = category_label(@category) %>
+  <% sample_names = @companies.first(3).map(&:name).join(", ") %>
+  <% faqs = [
+    [ "How many #{label} companies are based in Baltimore?",
+      "Baltimore.ai lists #{@companies.size} #{label} #{@companies.size == 1 ? 'company' : 'companies'} in or with significant presence in the Baltimore metro." ],
+    [ "Who are the most established #{label} companies in Baltimore?",
+      "Notable #{label} companies in Baltimore include #{sample_names}. See the full list above." ],
+    [ "Where in Baltimore is the #{label} cluster concentrated?",
+      "Baltimore-area #{label} companies are clustered around Johns Hopkins's East Baltimore campus, the bwtech@UMBC research park, and the I-95 / Fort Meade corridor between Baltimore and DC." ],
+    [ "How can a #{label} company get listed on Baltimore.ai?",
+      "Baltimore.ai accepts self-serve claims. If you work at a Baltimore-area #{label} company that should be listed, contact us or claim an existing listing to add or update an entry." ]
+  ] %>
+<script type="application/ld+json">
+<%=
+  ld = {
+    "@context" => "https://schema.org",
+    "@type" => "FAQPage",
+    "mainEntity" => faqs.map do |q, a|
+      {
+        "@type" => "Question",
+        "name" => q,
+        "acceptedAnswer" => { "@type" => "Answer", "text" => a }
+      }
+    end
+  }
+  raw ld.to_json
+%>
+</script>
+
+<section class="mt-16 border-t border-stone-200 pt-8 max-w-3xl">
+  <h2 class="text-xs uppercase tracking-wider text-stone-500 mb-4">Frequently asked</h2>
+  <dl class="space-y-6">
+    <% faqs.each do |q, a| %>
+      <div>
+        <dt class="font-semibold text-stone-900"><%= q %></dt>
+        <dd class="mt-1 text-stone-700"><%= a %></dd>
+      </div>
+    <% end %>
+  </dl>
+</section>
+<% end %>

--- a/app/views/guides/index.html.erb
+++ b/app/views/guides/index.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title, page_title("Guides to AI in Baltimore") %>
+<% content_for :meta_description, "Editorial guides to the AI scene in Baltimore — companies, labs, and where to learn." %>
+
+<%= render "shared/breadcrumbs", crumbs: [ [ "Home", root_path ], [ "Guides", nil ] ] %>
+
+<header class="mb-10">
+  <h1 class="text-4xl md:text-5xl font-black tracking-tight">Guides</h1>
+  <p class="mt-3 text-lg text-stone-600 max-w-2xl">
+    Hand-written, opinionated takes on the people, companies, and institutions shaping AI in Baltimore.
+  </p>
+</header>
+
+<% if @guides.any? %>
+  <ul class="divide-y divide-stone-200 border-y border-stone-200">
+    <% @guides.each do |guide| %>
+      <li class="py-6">
+        <%= link_to guide_path(guide), class: "block group" do %>
+          <h2 class="text-2xl font-black tracking-tight text-stone-900 group-hover:text-red-700"><%= guide.title %></h2>
+          <% if guide.intro.present? %>
+            <p class="mt-2 text-stone-600 max-w-2xl"><%= guide.intro %></p>
+          <% end %>
+          <p class="mt-2 text-xs uppercase tracking-wider text-stone-500">
+            <%= guide.published_at.strftime("%B %Y") %>
+          </p>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p class="text-stone-600">No guides published yet.</p>
+<% end %>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,0 +1,57 @@
+<% content_for :title, page_title(@guide.meta_title.presence || @guide.title) %>
+<% content_for :meta_description, (@guide.meta_description.presence || @guide.intro.to_s.truncate(160)) %>
+<% content_for :og_type, "article" %>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  [ "Home", root_path ],
+  [ "Guides", guides_path ],
+  [ @guide.title, nil ]
+] %>
+
+<article class="max-w-3xl">
+  <header class="border-b border-stone-200 pb-8 mb-8">
+    <p class="text-xs uppercase tracking-[0.2em] text-red-700 font-semibold mb-3">Guide · <%= @guide.published_at.strftime("%B %Y") %></p>
+    <h1 class="text-4xl md:text-5xl font-black tracking-tight leading-tight"><%= @guide.title %></h1>
+    <% if @guide.intro.present? %>
+      <p class="mt-4 text-xl text-stone-600 leading-relaxed"><%= @guide.intro %></p>
+    <% end %>
+  </header>
+
+  <div class="prose-editorial">
+    <%= render_markdown(@guide.body) %>
+  </div>
+</article>
+
+<% if @related.any? %>
+  <aside class="max-w-3xl mt-16 border-t border-stone-200 pt-8">
+    <h2 class="text-xs uppercase tracking-wider text-stone-500 mb-4">More guides</h2>
+    <ul class="space-y-3">
+      <% @related.each do |g| %>
+        <li>
+          <%= link_to guide_path(g), class: "block group" do %>
+            <div class="font-semibold text-stone-900 group-hover:text-red-700"><%= g.title %></div>
+            <% if g.intro.present? %>
+              <div class="text-sm text-stone-600 line-clamp-1"><%= g.intro %></div>
+            <% end %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </aside>
+<% end %>
+
+<script type="application/ld+json">
+<%=
+  ld = {
+    "@context" => "https://schema.org",
+    "@type" => "Article",
+    "headline" => @guide.title,
+    "description" => @guide.intro,
+    "datePublished" => @guide.published_at.iso8601,
+    "dateModified" => @guide.updated_at.iso8601,
+    "author" => { "@type" => "Organization", "name" => "Baltimore.ai" },
+    "publisher" => { "@type" => "Organization", "name" => "Baltimore.ai", "url" => request.base_url }
+  }.compact
+  raw ld.to_json
+%>
+</script>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -29,6 +29,27 @@
   </div>
 </section>
 
+<% if @guides.any? %>
+<section class="py-12 border-t border-stone-200">
+  <div class="flex items-baseline justify-between mb-6">
+    <h2 class="text-2xl font-black tracking-tight">Guides</h2>
+    <%= link_to "All guides →", guides_path, class: "text-sm text-stone-600 hover:text-stone-900" %>
+  </div>
+  <ul class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <% @guides.each do |guide| %>
+      <li class="bg-white border border-stone-200 rounded-md p-5 hover:border-stone-400">
+        <%= link_to guide_path(guide), class: "block group" do %>
+          <h3 class="font-black tracking-tight text-stone-900 group-hover:text-red-700 leading-snug"><%= guide.title %></h3>
+          <% if guide.intro.present? %>
+            <p class="mt-2 text-sm text-stone-600 line-clamp-3"><%= guide.intro %></p>
+          <% end %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</section>
+<% end %>
+
 <section class="py-12 border-t border-stone-200">
   <div class="flex items-baseline justify-between mb-6">
     <h2 class="text-2xl font-black tracking-tight">Categories</h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,7 @@
         <nav class="flex items-center gap-6 text-sm font-medium text-stone-600">
           <%= link_to "Companies", companies_path, class: "hover:text-stone-900" %>
           <%= link_to "Categories", categories_path, class: "hover:text-stone-900" %>
+          <%= link_to "Guides", guides_path, class: "hover:text-stone-900" %>
           <%= link_to "Resources", resources_path, class: "hover:text-stone-900" %>
         </nav>
       </div>
@@ -62,6 +63,7 @@
         </div>
         <div class="flex gap-6">
           <%= link_to "Companies", companies_path, class: "hover:text-stone-900" %>
+          <%= link_to "Guides", guides_path, class: "hover:text-stone-900" %>
           <%= link_to "Resources", resources_path, class: "hover:text-stone-900" %>
         </div>
       </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,16 +58,26 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST_NAME", "baltimore.ai"), protocol: "https" }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  # SMTP via env vars — defaults to Postmark.
+  # Required env vars when SMTP_USERNAME/SMTP_PASSWORD are set:
+  #   SMTP_ADDRESS (default: smtp.postmarkapp.com)
+  #   SMTP_PORT    (default: 587)
+  #   SMTP_USERNAME, SMTP_PASSWORD
+  if ENV["SMTP_USERNAME"].present?
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.perform_deliveries = true
+    config.action_mailer.raise_delivery_errors = true
+    config.action_mailer.smtp_settings = {
+      address: ENV.fetch("SMTP_ADDRESS", "smtp.postmarkapp.com"),
+      port: ENV.fetch("SMTP_PORT", 587).to_i,
+      user_name: ENV["SMTP_USERNAME"],
+      password: ENV["SMTP_PASSWORD"],
+      authentication: :plain,
+      enable_starttls_auto: true
+    }
+  end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :companies, only: [ :index, :show, :edit, :update ], param: :slug
   resources :categories, only: [ :index, :show ], param: :slug
   resources :resources, only: [ :index, :show ], param: :slug
+  resources :guides, only: [ :index, :show ], param: :slug
 
   # Sessions (magic link auth)
   get    "sign-in",         to: "sessions#new",     as: :sign_in_request

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -5,6 +5,11 @@ SitemapGenerator::Sitemap.create do
   add companies_path, priority: 0.9, changefreq: "weekly"
   add categories_path, priority: 0.7, changefreq: "monthly"
   add resources_path, priority: 0.7, changefreq: "monthly"
+  add guides_path,    priority: 0.8, changefreq: "weekly"
+
+  Guide.published.find_each do |guide|
+    add guide_path(guide), lastmod: guide.updated_at, priority: 0.9, changefreq: "monthly"
+  end
 
   Company.published.find_each do |company|
     add company_path(company), lastmod: company.updated_at, priority: 0.8, changefreq: "monthly"

--- a/db/migrate/20260506180218_create_guides.rb
+++ b/db/migrate/20260506180218_create_guides.rb
@@ -1,0 +1,20 @@
+class CreateGuides < ActiveRecord::Migration[8.1]
+  def change
+    create_table :guides do |t|
+      t.string :slug, null: false
+      t.string :title, null: false
+      t.text :intro
+      t.text :body, null: false
+      t.string :meta_title
+      t.string :meta_description
+      t.string :status, null: false, default: "draft"
+      t.datetime :published_at
+
+      t.timestamps
+    end
+
+    add_index :guides, :slug, unique: true
+    add_index :guides, :status
+    add_index :guides, :published_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_153442) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_180218) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,6 +55,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_153442) do
     t.index ["company_id", "tag_id"], name: "index_company_tags_on_company_id_and_tag_id", unique: true
     t.index ["company_id"], name: "index_company_tags_on_company_id"
     t.index ["tag_id"], name: "index_company_tags_on_tag_id"
+  end
+
+  create_table "guides", force: :cascade do |t|
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.text "intro"
+    t.string "meta_description"
+    t.string "meta_title"
+    t.datetime "published_at"
+    t.string "slug", null: false
+    t.string "status", default: "draft", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["published_at"], name: "index_guides_on_published_at"
+    t.index ["slug"], name: "index_guides_on_slug", unique: true
+    t.index ["status"], name: "index_guides_on_status"
   end
 
   create_table "profile_claims", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -213,6 +213,8 @@ COMPANIES = [
     tags: %w[cybersecurity-ai defense-ai],
     status: "published"
   },
+  # TODO(curator): Stride.ai's Baltimore presence is unverified. Hidden until confirmed
+  # or replaced. See pre-launch notes.
   {
     slug: "stride-pharma",
     name: "Stride.ai",
@@ -223,7 +225,7 @@ COMPANIES = [
     founded_year: 2017,
     employee_count_bucket: "51-200",
     tags: %w[natural-language-processing healthcare-ai fintech-ai],
-    status: "published"
+    status: "hidden"
   },
   {
     slug: "remesh",
@@ -321,6 +323,8 @@ COMPANIES = [
     tags: %w[healthcare-ai machine-learning],
     status: "published"
   },
+  # TODO(curator): Element Biosciences is San Diego-based. Hidden until a verified
+  # Baltimore-area office or substantive collaboration can be cited.
   {
     slug: "loop-genomics",
     name: "Element Biosciences (Baltimore presence)",
@@ -331,8 +335,10 @@ COMPANIES = [
     founded_year: 2017,
     employee_count_bucket: "201-500",
     tags: %w[genomics machine-learning biotech-ai],
-    status: "published"
+    status: "hidden"
   },
+  # TODO(curator): Vita Inclinata is Denver-based. Hidden until Baltimore connection
+  # can be substantiated.
   {
     slug: "cresta-baltimore",
     name: "Vita Inclinata",
@@ -343,8 +349,10 @@ COMPANIES = [
     founded_year: 2015,
     employee_count_bucket: "51-200",
     tags: %w[robotics defense-ai],
-    status: "published"
+    status: "hidden"
   },
+  # TODO(curator): Scopio is Israeli with US ops in Boston. Hidden until bwtech
+  # connection is verified directly with the company.
   {
     slug: "scopio-labs-bwtech",
     name: "Scopio Labs (Bwtech presence)",
@@ -355,7 +363,7 @@ COMPANIES = [
     founded_year: 2015,
     employee_count_bucket: "51-200",
     tags: %w[computer-vision healthcare-ai],
-    status: "published"
+    status: "hidden"
   },
   {
     slug: "qomplx",
@@ -369,6 +377,8 @@ COMPANIES = [
     tags: %w[cybersecurity-ai fintech-ai machine-learning],
     status: "published"
   },
+  # TODO(curator): Sparkfly is Atlanta-based and remote. Hidden — distributed team
+  # presence isn't a strong enough Baltimore claim.
   {
     slug: "argo-ai-baltimore",
     name: "Sparkfly",
@@ -379,8 +389,11 @@ COMPANIES = [
     founded_year: 2011,
     employee_count_bucket: "51-200",
     tags: %w[machine-learning fintech-ai],
-    status: "published"
+    status: "hidden"
   },
+  # TODO(curator): WillowTree is Charlottesville-HQ. They acquired Mindgrub but the
+  # "Baltimore studio" framing is still a stretch as a standalone entry. Hidden
+  # in favor of keeping the Mindgrub entry.
   {
     slug: "lumen-ai-baltimore",
     name: "WillowTree (Baltimore studio)",
@@ -391,7 +404,7 @@ COMPANIES = [
     founded_year: 2008,
     employee_count_bucket: "1000+",
     tags: %w[ai-consulting llm],
-    status: "published"
+    status: "hidden"
   },
   {
     slug: "rooferrate",
@@ -536,8 +549,12 @@ end
 
 puts "  -> #{Resource.count} resources (#{Resource.published.count} published)"
 
+puts "Seeding guides..."
+load Rails.root.join("db/seeds/guides.rb")
+
 puts ""
 puts "Seed complete."
 puts "  Tags:      #{Tag.count}"
 puts "  Companies: #{Company.count} (#{Company.published.count} published)"
 puts "  Resources: #{Resource.count} (#{Resource.published.count} published)"
+puts "  Guides:    #{Guide.count} (#{Guide.published.count} published)"

--- a/db/seeds/guides.rb
+++ b/db/seeds/guides.rb
@@ -1,0 +1,258 @@
+# Editorial guides for baltimore.ai. Hand-written, opinionated, intentionally
+# avoiding generic SEO mush. Each guide is the "top X" content the plan calls for —
+# they outrank pure facet pages for head queries.
+#
+# Loaded from db/seeds.rb. Idempotent.
+
+GUIDES = [
+  {
+    slug: "ai-companies-baltimore-2026",
+    title: "AI companies in Baltimore: a 2026 field guide",
+    intro: "There isn't a single 'Baltimore AI scene' — there are at least three, and they barely talk to each other.",
+    meta_title: "AI companies in Baltimore (2026)",
+    meta_description: "An opinionated field guide to the AI companies, sub-clusters, and quiet patterns shaping AI in Baltimore in 2026.",
+    body: <<~MD
+      Most lists of "AI companies in Baltimore" make the same mistake: they collapse three very different kinds of company into one alphabetized blob. The applied-AI startups in Hampden don't talk to the Hopkins APL spinouts in Laurel, and neither of them talks to the cybersecurity-AI cluster around Ellicott City and Columbia. So before the list, the map.
+
+      ## The three Baltimore AI scenes
+
+      **Healthcare and life-sciences AI** is the densest cluster, and it's almost entirely a Hopkins phenomenon. [Personal Genome Diagnostics](/companies/personal-genome-diagnostics) (now Labcorp), [Haystack Oncology](/companies/haystack-oncology) (acquired by Quest), [Protenus](/companies/protenus), [Sonavex](/companies/sonavex), [Emocha Health](/companies/emocha-health) — these are companies whose founding teams overlap, whose papers cite each other, and whose existence is downstream of decades of NIH and Johns Hopkins funding. If you walk into any of them, you'll find the same dozen people on each other's advisory boards.
+
+      **Cybersecurity AI** is the loudest and most commercial cluster. [Tenable](/companies/tenable), [ZeroFox](/companies/zerofox), [Huntress](/companies/huntress), [Blackpoint Cyber](/companies/blackpoint-cyber), [QOMPLX](/companies/qomplx), [CyberPoint International](/companies/cyberpoint) — most of these are not headquartered in Baltimore proper but in the suburbs along the I-95 / NSA corridor. They share an unusual hiring pool: former NSA, former military, and Hopkins APL alumni. AI in this cluster is mostly ML for anomaly detection and triage, not LLMs for chat.
+
+      **Generalist applied AI and consulting** is the smallest but most visible cluster. [RedShred](/companies/redshred), [Mindgrub](/companies/mindgrub), [Fearless](/companies/fearless), [Huntr](/companies/huntr) — these are the companies that show up at local meetups and run the city's AI Twitter discourse. They're the ones building LLM-powered features for clients and shipping consumer-ish products. If you're new to Baltimore tech, this is the cluster you'll meet first; it's also the one that gets most of the press coverage despite being the smallest by headcount.
+
+      ## What's missing
+
+      A few categories Baltimore conspicuously lacks compared to peer cities:
+
+      - **No serious AI infrastructure company.** No Modal, no Anyscale, no Pinecone analogue. The closest is some of [Tenable](/companies/tenable)'s internal ML platform work, but nothing customer-facing.
+      - **Limited consumer AI.** [Huntr](/companies/huntr) is the rare counterexample. Most Baltimore AI is B2B or B2G.
+      - **Weak open-source presence.** Despite the research density, very little of it ends up on GitHub at the company level.
+
+      ## Why this matters for hiring
+
+      If you're moving here for AI work, the cluster you join shapes what your career looks like more than the company name does. Healthcare AI means slow regulatory cycles, deep specialization, and acquisitions to incumbents (PGDx → Labcorp, Haystack → Quest). Cybersecurity AI means faster commercial cycles, security-cleared work, and IPO-or-PE outcomes (ZeroFox, Tenable). Applied AI consulting means project variety and lower equity ceiling.
+
+      ## What to read next
+
+      - [Healthcare AI in Baltimore: the Hopkins effect](/guides/healthcare-ai-baltimore-hopkins) — the dense interconnections in the medical cluster.
+      - [Cybersecurity AI in the Baltimore-DC corridor](/guides/cybersecurity-ai-baltimore-dc-corridor) — why the I-95 cluster is what it is.
+      - [Where to learn AI in Baltimore](/guides/where-to-learn-ai-baltimore) — universities, programs, and the free options.
+
+      ---
+
+      *Last updated May 2026. Found something missing or wrong? [Claim your listing](/companies) or get in touch.*
+    MD
+  },
+  {
+    slug: "healthcare-ai-baltimore-hopkins",
+    title: "Healthcare AI in Baltimore: the Hopkins effect",
+    intro: "The healthcare-AI cluster in Baltimore is one of the densest in the country — and it's almost entirely downstream of Johns Hopkins.",
+    meta_title: "Healthcare AI companies in Baltimore",
+    meta_description: "How Johns Hopkins shaped Baltimore's healthcare and life-sciences AI cluster — the companies, the spinouts, and the patterns.",
+    body: <<~MD
+      You can almost draw a line on a map. Start at the East Baltimore campus of Johns Hopkins. Trace south to [Personal Genome Diagnostics](/companies/personal-genome-diagnostics) (founded by Hopkins researchers, acquired by Labcorp). North to [Sonavex](/companies/sonavex) (a Hopkins spinout building AI ultrasound). East to [Protenus](/companies/protenus) (founded by Hopkins MD-PhDs). The same dozen advisors, board members, and post-doc cohort show up on every cap table.
+
+      This is unusual. Most "healthcare AI hubs" — Boston, the Bay Area, San Diego — have multiple research feeders. Baltimore essentially has one, plus University of Maryland Medical Center as a distant second. That concentration has trade-offs.
+
+      ## What the Hopkins effect looks like
+
+      **Founding teams skew clinician-engineer.** A typical Baltimore healthcare-AI company has at least one MD-PhD on the founding team — often a Hopkins faculty member with a part-time appointment. This is different from Bay Area healthcare AI, which is more often pure-engineering teams partnering with health systems.
+
+      **Acquisition is the dominant exit.** [Haystack Oncology](/companies/haystack-oncology) → Quest Diagnostics (2023). [Personal Genome Diagnostics](/companies/personal-genome-diagnostics) → Labcorp (2022, eventually). [Sonavex](/companies/sonavex) is widely expected to go the same way. There aren't many IPOs from this cluster — partly the regulatory cycle, partly the reality that diagnostics and devices fit cleanly inside large incumbents.
+
+      **Research-to-startup latency is short.** A pattern that recurs: a Hopkins lab publishes a paper showing an ML method outperforms standard-of-care on some clinical decision. Within 18 months, there's a startup. [Sonavex](/companies/sonavex) followed this pattern. [Haystack](/companies/haystack-oncology) followed this pattern. It's a great pipeline; it also means the cluster is unusually exposed to NIH funding cycles.
+
+      ## The Hopkins ecosystem support
+
+      Three institutions matter most for new healthcare-AI founders here:
+
+      - **[Johns Hopkins Technology Ventures](https://ventures.jhu.edu)** — the licensing arm, the [FastForward U](/resources/fastforward-u) accelerator, and an active venture capital fund.
+      - **[JHU MINDS](/resources/jhu-mathematical-institute-data-science)** — the cross-school AI/ML research institute. Most of the foundational ML work that becomes startups comes through MINDS-affiliated labs.
+      - **[JHU Data Science and AI Institute (DSAI)](/resources/jhu-data-science-and-ai-institute)** — the new (2024) university-wide AI institute. Too soon to tell what it produces, but the early bets are aggressive.
+
+      Outside Hopkins, [TEDCO](/resources/tedco) is the most active early-stage capital source — it's done dozens of small checks into Maryland life-sciences and AI startups, and it's much friendlier to non-traditional founders than the Hopkins channel.
+
+      ## What's underserved
+
+      A few patterns the Baltimore healthcare-AI cluster is bad at:
+
+      - **Consumer-facing health AI.** Almost everything here is B2B sold into health systems and pharma. Direct-to-patient products are rare.
+      - **Mental health AI.** Despite Hopkins's psychiatry strength, there's no real Baltimore startup analogue to [Spring Health](https://www.springhealth.com) or [Lyra](https://www.lyrahealth.com).
+      - **AI in administrative health workflows.** Prior auth, RCM, scheduling — these are huge markets and Baltimore is barely participating. This is a gap, not a feature.
+
+      ## What to read next
+
+      - [AI companies in Baltimore: a 2026 field guide](/guides/ai-companies-baltimore-2026) — the broader map.
+      - [Hopkins APL: spinouts and the unsung half of Baltimore AI](/guides/hopkins-apl-spinouts) — the other Hopkins.
+
+      ---
+
+      *Last updated May 2026.*
+    MD
+  },
+  {
+    slug: "cybersecurity-ai-baltimore-dc-corridor",
+    title: "Cybersecurity AI in the Baltimore-DC corridor",
+    intro: "The strip of I-95 between Baltimore and DC is one of the densest cybersecurity-AI clusters on Earth. Most people outside the industry don't know it exists.",
+    meta_title: "Cybersecurity AI companies in Baltimore",
+    meta_description: "A guide to the cybersecurity-AI cluster between Baltimore and DC — the companies, the talent flows, and the unusual constraints.",
+    body: <<~MD
+      Drive south on I-95 from Baltimore. In about thirty minutes you'll pass within a few miles of: NSA headquarters at Fort Meade, Johns Hopkins APL in Laurel, the offices of [Tenable](/companies/tenable), [ZeroFox](/companies/zerofox), [Huntress](/companies/huntress), [Blackpoint Cyber](/companies/blackpoint-cyber), [QOMPLX](/companies/qomplx), and [CyberPoint International](/companies/cyberpoint). It's one of the most concentrated cybersecurity-AI clusters anywhere — and it's invisible from outside the industry because almost all of these companies sell to enterprises, governments, and other security companies.
+
+      ## Why this cluster exists where it does
+
+      The honest answer: NSA. Fort Meade has been pumping out cybersecurity talent for fifty years, and after the [Snowden disclosures](https://en.wikipedia.org/wiki/Edward_Snowden) accelerated NSA-to-private-sector flow, that talent largely stayed in Maryland. [Blackpoint Cyber](/companies/blackpoint-cyber) was founded by former NSA staff. So were many of the technical leads at [Tenable](/companies/tenable), [ZeroFox](/companies/zerofox), and [CyberPoint](/companies/cyberpoint). Hopkins APL contributes a separate but adjacent talent stream.
+
+      Add the federal customer base — DC is right there — and you have the conditions for a self-sustaining cluster.
+
+      ## What "cybersecurity AI" means here
+
+      It is mostly *not* what consumer AI press covers. There are very few LLM products in this cluster. What you'll find instead:
+
+      - **Anomaly detection on telemetry.** Endpoint, network, identity, cloud — the volumes are so large that ML triage is the only way to make human analysts effective. [Huntress](/companies/huntress) and [Tenable](/companies/tenable) are the canonical examples.
+      - **Graph-based threat modeling.** [QOMPLX](/companies/qomplx) leans heavily into graph analytics over enterprise telemetry to score risk.
+      - **NLP on threat intelligence.** [ZeroFox](/companies/zerofox) is the loudest example — public web and dark web monitoring with NLP at the core.
+      - **Adversarial ML research.** Less commercialized, mostly inside [Hopkins APL](/resources/johns-hopkins-apl), [CyberPoint](/companies/cyberpoint), and federal labs.
+
+      ## The hiring market is unusual
+
+      Several things to know if you're considering joining this cluster:
+
+      1. **Many roles require security clearances.** This narrows the candidate pool dramatically and pushes salaries up. If you don't have a clearance, [Huntress](/companies/huntress) and [Tenable](/companies/tenable)'s commercial sides are your most accessible entry points.
+      2. **Career mobility within the cluster is high.** People rotate between [ZeroFox](/companies/zerofox), [Tenable](/companies/tenable), [Blackpoint](/companies/blackpoint-cyber), and APL like it's one company. If you join one, you've effectively joined all of them.
+      3. **The product engineering culture is conservative.** These companies sell to security-conscious customers. Trunk-based development with feature flags and continuous deployment is rare. Releases are scheduled, regression-tested, and signed off.
+
+      ## What's not happening here (yet)
+
+      A few categories the cluster is underweight in:
+
+      - **AI-for-AI-security.** As LLM applications proliferate, the security stack for them — prompt injection defense, model supply chain, agent sandboxing — is mostly being built in the Bay Area. The Baltimore-DC cluster has the talent for this and isn't moving fast enough.
+      - **Consumer-facing security AI.** Apart from password managers and a few SMB-targeted MDR products, the cluster doesn't really do consumer.
+
+      ## What to read next
+
+      - [AI companies in Baltimore: a 2026 field guide](/guides/ai-companies-baltimore-2026)
+      - [Hopkins APL: spinouts and the unsung half of Baltimore AI](/guides/hopkins-apl-spinouts)
+
+      ---
+
+      *Last updated May 2026.*
+    MD
+  },
+  {
+    slug: "hopkins-apl-spinouts",
+    title: "Hopkins APL: spinouts and the unsung half of Baltimore AI",
+    intro: "Johns Hopkins Applied Physics Laboratory is one of the largest applied-AI research labs in the world. Most Baltimoreans don't think of it when they think of Baltimore AI.",
+    meta_title: "Johns Hopkins APL: AI research and spinouts",
+    meta_description: "Johns Hopkins APL employs thousands of AI researchers in Laurel, MD. Here's how it shapes Baltimore's broader AI ecosystem and what it spins out.",
+    body: <<~MD
+      Mention Baltimore AI and most people think of [Hopkins's medical campus](/guides/healthcare-ai-baltimore-hopkins). They should also be thinking about Laurel.
+
+      [Johns Hopkins Applied Physics Laboratory](/resources/johns-hopkins-apl) — APL — is a federally funded research and development center about a thirty-minute drive south of Baltimore proper. It employs over 8,000 people, a meaningful fraction of whom work on AI: foundation models for science, multi-agent autonomy, computer vision for defense, ML systems research, trustworthy AI. By any reasonable count it's one of the largest applied-AI organizations in the world. And it's quietly the source of a substantial share of the people who now staff Baltimore's commercial AI cluster.
+
+      ## What APL actually works on
+
+      APL's portfolio is broad enough that any summary is approximate, but the AI-relevant pieces include:
+
+      - **Autonomous systems** for naval, air, and space platforms. Multi-agent coordination, planning under uncertainty, sim-to-real transfer.
+      - **AI for science.** Materials discovery, climate modeling, biomedical foundation models — APL has a growing presence here, often in partnership with the broader Hopkins research enterprise.
+      - **Trustworthy ML.** Adversarial robustness, model verification, formal methods. APL ships products that need to meet defense-grade reliability bars, which forces a different relationship with ML than most commercial teams have.
+      - **National security AI.** A large portfolio you can't read about in detail.
+
+      The unifying theme: APL works on AI under constraints most commercial teams don't face — adversarial inputs, hardware-in-the-loop, lives on the line. That changes how the engineers there think.
+
+      ## The diaspora
+
+      APL alumni are everywhere in the Baltimore-DC cluster. You'll find them at [CyberPoint](/companies/cyberpoint), [QOMPLX](/companies/qomplx), [Blackpoint Cyber](/companies/blackpoint-cyber), and at most of the cybersecurity-AI companies in the [I-95 corridor](/guides/cybersecurity-ai-baltimore-dc-corridor). They tend to share a few traits: high comfort with adversarial threat models, lower tolerance for "ship it and iterate," strong systems-engineering instincts.
+
+      Direct APL spinouts are rarer — APL's IP arrangements with the federal government make spinning out harder than at a typical university lab — but the talent flow is the dominant channel of impact on the commercial scene.
+
+      ## How to engage with APL if you're outside it
+
+      A few entry points:
+
+      - **APL public talks and seminars.** Many AI seminars are open to outside attendees. The schedule is patchy; keep an eye on [APL's events page](https://www.jhuapl.edu).
+      - **Postdoc and rotation programs.** APL has several pipelines for early-career researchers, including joint appointments with Hopkins's main campus.
+      - **SBIR partnerships.** If you have a startup with a federal angle, APL's industry-engagement teams are unusually willing to talk.
+
+      ## What it means for the rest of Baltimore AI
+
+      The APL effect on the commercial cluster is mostly invisible from outside. It shows up as: a deeper bench of ML engineers with security clearances, a higher floor on technical rigor in cybersecurity-AI, and an unusual concentration of "applied AI" expertise — meaning AI that has to work in the real world under hostile conditions, not just produce a demo.
+
+      ## What to read next
+
+      - [Cybersecurity AI in the Baltimore-DC corridor](/guides/cybersecurity-ai-baltimore-dc-corridor) — where most APL alumni land.
+      - [Where to learn AI in Baltimore](/guides/where-to-learn-ai-baltimore).
+
+      ---
+
+      *Last updated May 2026.*
+    MD
+  },
+  {
+    slug: "where-to-learn-ai-baltimore",
+    title: "Where to learn AI in Baltimore",
+    intro: "Universities, programs, meetups, and the free option — a practical guide to picking up AI skills in the Baltimore metro.",
+    meta_title: "Where to learn AI in Baltimore (universities & programs)",
+    meta_description: "An honest guide to learning AI in Baltimore — universities, accelerators, meetups, and how to start without spending a dollar.",
+    body: <<~MD
+      The honest version of this guide is: you can learn AI from anywhere, and the most credentialed paths in Baltimore are also the most expensive. That said, there are real reasons to learn here specifically — proximity to the people doing the work, access to research seminars, and a meaningful local job market that's hungry for talent.
+
+      Here's how to think about your options.
+
+      ## If you want a degree
+
+      **[Johns Hopkins University](/resources/jhu-data-science-and-ai-institute)** is the obvious choice and the most expensive. Hopkins's CS department has multiple AI/ML faculty who are world-class; the [MINDS institute](/resources/jhu-mathematical-institute-data-science) coordinates AI research across schools; the new [DSAI institute](/resources/jhu-data-science-and-ai-institute) (2024) is the most aggressive bet on AI Hopkins has ever made. Programs to look at: the MS in Computer Science with an ML focus, the MS in Artificial Intelligence (Engineering for Professionals, online and part-time), and the Whiting School PhD if you're going the research route.
+
+      **[University of Maryland, Baltimore County (UMBC)](/resources/umbc-ai-cybersecurity-collaboratory)** has a strong CS department with active AI research groups, especially in NLP, knowledge graphs, and ML systems. UMBC tuition is meaningfully lower than Hopkins's, the program is rigorous, and the campus sits adjacent to the [bwtech research park](/resources/bwtech-umbc) so industry exposure is built in. For most people learning AI in Baltimore, UMBC is the better value.
+
+      **University of Maryland, College Park** is technically not Baltimore, but it's close enough that you can commute and it has one of the strongest AI/ML programs on the East Coast. If you're degree-shopping, don't ignore it.
+
+      ## If you don't want a degree
+
+      A few options that work:
+
+      - **[FastForward U](/resources/fastforward-u)**, JHU's startup accelerator, runs programming aimed at student and alumni founders, but it also produces a lot of learnable content. Many of their workshops are open to non-students.
+      - **[Baltimore AI/ML Meetup](/resources/baltimore-ai-meetup)** is the most reliable monthly touchpoint for the local practitioner community. Free, mixed-skill audiences, talks range from intro to research-level.
+      - **APL public seminars.** [Hopkins APL](/resources/johns-hopkins-apl) runs public AI seminars throughout the year. The talks are technical but accessible, and you'll meet people you can't easily meet otherwise.
+      - **TEDCO programs.** [TEDCO](/resources/tedco) runs regular events for Maryland tech founders, several of which include AI-specific programming.
+
+      ## The free path
+
+      You don't need any of the above to get good. The same free resources that have built a generation of AI engineers — [Karpathy's Zero-to-Hero](https://karpathy.ai), [fast.ai](https://www.fast.ai), [3Blue1Brown's neural network series](https://www.3blue1brown.com), the [original Transformer paper](https://arxiv.org/abs/1706.03762), and a steady diet of arxiv-sanity — work just as well from a Baltimore apartment as anywhere else. What being in Baltimore adds is a community to test your understanding against and a job market to land in.
+
+      A reasonable self-taught track for someone in Baltimore today:
+
+      1. Three months of fundamentals (linear algebra refresher, Python, fast.ai, Karpathy's nn-zero-to-hero series).
+      2. Pick a project. Ship it. Talk about it at the AI/ML meetup.
+      3. Apply to entry-level ML roles at the [companies in our directory](/companies). Many of them prefer self-taught engineers with portfolio over fresh CS grads with no project.
+
+      ## What you can't easily get here
+
+      Baltimore is weak on a few things:
+
+      - **Pure ML research community at scale.** Hopkins and APL are excellent, but the conversation density is lower than Boston or the Bay Area. If you want to be deeply embedded in research, plan for travel.
+      - **Generative-AI / LLM specialization.** The local cluster skews ML-on-data, not LLM-application. You'll find better LLM-specific content online than in Baltimore meetups.
+
+      ## What to read next
+
+      - [AI companies in Baltimore: a 2026 field guide](/guides/ai-companies-baltimore-2026) — what jobs you're aiming at.
+      - [Healthcare AI in Baltimore: the Hopkins effect](/guides/healthcare-ai-baltimore-hopkins).
+
+      ---
+
+      *Last updated May 2026.*
+    MD
+  }
+].freeze
+
+GUIDES.each do |attrs|
+  guide = Guide.find_or_initialize_by(slug: attrs[:slug])
+  guide.assign_attributes(attrs.merge(status: "published"))
+  guide.published_at ||= Time.current
+  guide.save!
+end
+
+puts "  -> #{Guide.count} guides (#{Guide.published.count} published)"

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -13,8 +13,20 @@ fly postgres attach --app baltimore-ai baltimore-ai-db
 # 3. Set secrets
 fly secrets set RAILS_MASTER_KEY=$(cat config/master.key)
 fly secrets set APP_HOST=https://baltimore.ai
+fly secrets set APP_HOST_NAME=baltimore.ai
+fly secrets set MAIL_FROM="Baltimore.ai <hello@baltimore.ai>"
+fly secrets set ADMIN_EMAIL=you@yourdomain.com
 
-# 4. Deploy
+# 4. Configure outbound email (Postmark)
+#    a. Sign up at postmarkapp.com
+#    b. Verify the baltimore.ai sender domain (DKIM + Return-Path DNS records)
+#    c. Generate a server token; that's the SMTP password
+fly secrets set SMTP_USERNAME=<postmark-server-token> SMTP_PASSWORD=<same-token>
+# Optional, defaults to Postmark:
+#   SMTP_ADDRESS=smtp.postmarkapp.com
+#   SMTP_PORT=587
+
+# 5. Deploy
 fly deploy
 ```
 

--- a/docs/LAUNCH.md
+++ b/docs/LAUNCH.md
@@ -1,0 +1,141 @@
+# Launch checklist for baltimore.ai
+
+A pragmatic, ordered runbook for going from "deployed" to "publicly launched." Designed for solo execution — about a week of part-time effort end to end.
+
+## 1. Deploy (day 1)
+
+Follow [DEPLOY.md](DEPLOY.md). Ends with:
+- baltimore.ai resolving to Fly behind HTTPS
+- Postmark configured and a test email delivered to your own inbox
+- `/up` returning 200
+- `bin/rails db:seed` run on production with `ADMIN_EMAIL=you@yourdomain.com`
+
+Do not announce the launch yet.
+
+## 2. Self-test the claim flow (day 1)
+
+Before anyone else hits the site:
+
+- [ ] Visit `/companies/redshred` (or any unclaimed listing).
+- [ ] Click "Claim this listing."
+- [ ] Enter your name + an email at a domain you control.
+- [ ] Confirm code arrives via Postmark.
+- [ ] Walk all 4 wizard steps; complete the claim.
+- [ ] Verify the listing now shows "Claimed" and you can edit.
+- [ ] Visit `/admin/profile_claims` — verify the claim appears as `auto_approved`.
+- [ ] Sign out. Visit `/sign-in`. Request a magic link. Confirm sign-in works.
+
+If any step fails, fix before proceeding.
+
+## 3. Search engine verification (day 2)
+
+- [ ] **Google Search Console**: Add `https://baltimore.ai` (URL prefix property). Verify via DNS TXT or HTML file.
+- [ ] **Bing Webmaster Tools**: Same.
+- [ ] Submit `https://baltimore.ai/sitemap.xml.gz` to both.
+- [ ] In GSC, request indexing for: `/`, `/companies`, `/guides`, `/companies/redshred` (or any 1 company), `/guides/ai-companies-baltimore-2026`.
+
+## 4. Citations (days 2-4)
+
+The plan flagged these as priority citations. Submit baltimore.ai to each:
+
+- [ ] **[Technical.ly Baltimore](https://technical.ly/baltimore/)** — pitch via their tip line; their reporters cover this beat.
+- [ ] **[Baltimore Business Journal](https://www.bizjournals.com/baltimore/)** — same; their tech reporter is the right contact.
+- [ ] **[Economic Alliance of Greater Baltimore (EAGB)](https://greaterbaltimore.org/)** — listed as a regional resource.
+- [ ] **[Greater Baltimore Committee](https://gbc.org/)** — they maintain a tech ecosystem map.
+- [ ] **[FastForward U](https://ventures.jhu.edu/fastforward/)** — they have a community-resources page.
+- [ ] **Baltimore Inno** — Inno markets keep a regional tech directory.
+
+For each: send a short note explaining baltimore.ai exists, what it does, and asking them to link from their resources / ecosystem-map / member-directory page. Aim for 5 inbound links by end of week 1.
+
+## 5. Direct outreach to seeded companies (days 3-5)
+
+The plan's success metric: **40% of seeded listings claimed within 90 days.** That requires direct outreach. Email founders/marketing leads at the first ~10 most prominent seeded companies:
+
+- [ ] [RedShred](https://baltimore.ai/companies/redshred)
+- [ ] [Mindgrub](https://baltimore.ai/companies/mindgrub)
+- [ ] [Fearless](https://baltimore.ai/companies/fearless)
+- [ ] [Protenus](https://baltimore.ai/companies/protenus)
+- [ ] [Sonavex](https://baltimore.ai/companies/sonavex)
+- [ ] [ZeroFox](https://baltimore.ai/companies/zerofox)
+- [ ] [Tenable](https://baltimore.ai/companies/tenable)
+- [ ] [Huntress](https://baltimore.ai/companies/huntress)
+- [ ] [Blackpoint Cyber](https://baltimore.ai/companies/blackpoint-cyber)
+- [ ] [QOMPLX](https://baltimore.ai/companies/qomplx)
+
+### Outreach template
+
+```
+Subject: Baltimore.ai listing for [Company]
+
+Hi [name],
+
+I run baltimore.ai, a new directory of AI companies and resources in the
+Baltimore metro. I've added [Company] to the directory because you're one
+of the [healthcare AI / cybersecurity AI / etc.] companies that anchor the
+local cluster — current listing here:
+
+  https://baltimore.ai/companies/[slug]
+
+I wrote a short editorial blurb based on public information. You can claim
+the listing in about two minutes (we email a verification code to your work
+domain) and then edit it directly:
+
+  https://baltimore.ai/claim/[slug]
+
+If anything in the description is wrong, claim and fix it; if you'd rather
+not be listed at all, just reply and I'll remove it.
+
+— [your name]
+```
+
+## 6. Public launch (day 6-7)
+
+Pick one weekday. Sequence:
+
+- [ ] **Show HN**: post in the morning (US East). Title: "Show HN: baltimore.ai — directory of AI companies in Baltimore." First comment from your own account explaining why you built it (10-year domain, etc.).
+- [ ] **Twitter/X**: thread from @justuseapen. Lead with the strongest editorial take from a guide (the field-guide intro line is good: "There isn't a single Baltimore AI scene — there are at least three").
+- [ ] **LinkedIn**: same content, more company-focused angle. Tag 2-3 of the founders you've reached out to.
+- [ ] **Local Slack/Discord**: Baltimore tech community spaces (look for ones tied to Tech Council of Maryland, ETC, FastForward U).
+- [ ] **Hacker News (Show HN)** later in the day if traction is good elsewhere.
+- [ ] **ProductHunt**: optional. PH is more useful for SaaS than directories; only do it if you have a strong launch image and 5-10 hunters lined up.
+
+## 7. Post-launch monitoring (week 2+)
+
+- [ ] Check `/admin` daily for pending review claims.
+- [ ] Check Search Console weekly for indexing progress and impressions.
+- [ ] Track claim rate: how many of the 24 published listings get claimed in 30 days? Aim for ≥10.
+- [ ] Track inbound links via Search Console "Links" report.
+
+## 8. DNS cutover from Marcaria
+
+Currently `baltimore.ai` resolves wherever Marcaria's default DNS points. After Fly is set up:
+
+- [ ] At Marcaria, update nameservers OR add A/AAAA records pointing at Fly.
+- [ ] `fly certs add baltimore.ai && fly certs add www.baltimore.ai`
+- [ ] Confirm both apex and www resolve.
+- [ ] Eventually consider transferring the domain to Cloudflare Registrar — significantly cheaper for `.ai` and you get free DNS + WAF + edge caching.
+
+## 9. Honest pre-launch flags
+
+Things to do *before* you publicly announce, not after:
+
+- [ ] **Verify the 6 hidden seed entries** (Stride.ai, Element Biosciences, Vita Inclinata, Scopio, Sparkfly, WillowTree). Either confirm a real Baltimore connection and republish, or delete from the seed entirely. Currently they're hidden with TODO comments in `db/seeds/...` — see `db/seeds.rb`.
+- [ ] **Walk the site on a real phone.** Not just headless 1280px. Especially the claim wizard.
+- [ ] **Read each of the 5 guides aloud**, looking for: factual errors, dated claims, broken internal links, anything that sounds like generic AI content.
+- [ ] **Open every outbound link** in the seeded companies and resources to make sure none have died since you wrote the blurb.
+
+## 10. Out of scope (fine to defer)
+
+These are real but not worth blocking launch on:
+
+- People entity (founders, engineers)
+- Newsletter
+- Events / meetup calendar
+- Job board
+- Comparison pages (`/compare/a-vs-b`)
+- Public API
+- Featured / paid listings
+
+---
+
+**Rough timeline:** day 1 deploy + self-test, days 2-4 verification + citations, days 3-5 outreach, day 6-7 launch, week 2+ monitor.

--- a/docs/plans/2026-05-05-feat-baltimore-ai-directory-mvp-plan.md
+++ b/docs/plans/2026-05-05-feat-baltimore-ai-directory-mvp-plan.md
@@ -226,7 +226,7 @@ Word count isn't a ranking factor; **topical coverage is**. Each company page ta
 - [x] sitemap.xml lists all published companies, resources, categories, and guides.
 - [x] robots.txt allows crawling of public pages, disallows `/admin`, `/claim`.
 - [x] At least 30 seeded companies + 10 resources visible at launch.
-- [ ] 5 handcrafted `/guides/[slug]` "top X" editorial pages live at launch.
+- [x] 5 handcrafted `/guides/[slug]` "top X" editorial pages live at launch.
 
 ### Non-functional
 - [ ] Lighthouse SEO score ≥95 on home, `/companies`, `/companies/[slug]`, a category hub.


### PR DESCRIPTION
## Summary

Final pre-launch PR. Brings the MVP plan to a launchable state.

**Editorial guides (5 hand-written):**
- AI companies in Baltimore: a 2026 field guide
- Healthcare AI in Baltimore: the Hopkins effect
- Cybersecurity AI in the Baltimore-DC corridor
- Hopkins APL: spinouts and the unsung half of Baltimore AI
- Where to learn AI in Baltimore

Each is ~600-1000 words, opinionated, with internal links into the directory. Ranked-content style — these are designed to outrank pure facet pages for head queries (per the plan's SEO research).

Backed by a `Guide` model, markdown via `commonmarker`, custom `.prose-editorial` CSS (skipped the typography plugin to avoid npm — Tailwind v4 standalone), `Article` JSON-LD per guide.

**Production email:**
- Postmark SMTP wired via env vars; falls back to no-op when not configured
- DEPLOY.md updated with full Postmark setup walkthrough

**Pre-launch seed honesty pass:**
- 6 entries with weak Baltimore connections (Stride.ai, Element Biosciences, Vita Inclinata, Scopio, Sparkfly, WillowTree) set to `status=hidden`
- TODO(curator) comments on each, explaining why
- Published count drops 30 → 24, all defensible

**FAQPage JSON-LD on category hubs:**
- 4 dynamically-generated Qs per category (count, notable companies, geographic cluster, listing process)
- Visible FAQ section for users; structured data for People-Also-Ask

**Launch checklist:**
- `docs/LAUNCH.md` — runbook from deploy → self-test → GSC/Bing → citations → outreach → public launch
- Includes outreach email template for seeded companies

## Verification

- [x] All 5 guides render at `/guides/[slug]` — visual check on `/guides/ai-companies-baltimore-2026`
- [x] Home page shows guides block; nav link in header + footer
- [x] Sitemap regenerated includes all 5 guide URLs
- [x] Category page emits valid `FAQPage` JSON-LD (parsed via Ruby JSON parser)
- [x] All 5 integration tests still pass
- [x] Rubocop clean (53 files, 0 offenses)
- [x] 6 stretchy seed entries confirmed hidden via `Company.where(status: "hidden").pluck(:name)`

## Honest flags

- **Hidden seed entries are not deleted** — they're still in the seed file with TODO comments. Decision deferred to user.
- **Some guide content makes claims I can't fully cite** — e.g. "ZeroFox went public in 2022," APL employee count, etc. These are based on public knowledge from before training cutoff. Worth a fact-check pass before broad promotion.
- **No mobile/Core Web Vitals verification on a real device** — still TODO from Phase 1.
- **Guides have no admin UI** — adding/editing requires editing `db/seeds/guides.rb` and re-seeding. Adequate for the launch volume; revisit if guide cadence picks up.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - GSC: indexing status of new guide URLs (manually request indexing for each at launch)
  - Logs: search for `GuidesController` requests; watch for 404s on guide slugs
  - Postmark: delivery rate, bounce rate (target <2% bounce)
- **Validation queries**
  - `Guide.published.count` → 5 (should remain stable)
  - `Company.published.count` → 24 (will grow with claims)
  - `ProfileClaim.where("created_at > ?", 1.day.ago).count` — daily claim attempts (post-launch should be >0)
- **Expected healthy behavior**
  - All 5 guides indexed within 14 days of GSC submission
  - First 100 organic visits within 30 days of launch
  - First inbound link from Technical.ly / BBJ / EAGB within 21 days
- **Failure signals**
  - Postmark bounce rate >5% → check sender domain DKIM/SPF
  - Any guide page returning 5xx → roll back, this is the most-linked content
  - GSC "Excluded by 'noindex'" on category hubs → bug in thin-facet logic
- **Rollback**
  - `fly deploy --image <prior>` reverts code; guides + hidden statuses persist in DB
- **Validation window & owner**
  - 30 days post-launch, owner: @justuseapen

## Plan

[docs/plans/2026-05-05-feat-baltimore-ai-directory-mvp-plan.md](docs/plans/2026-05-05-feat-baltimore-ai-directory-mvp-plan.md) — all functional acceptance criteria now met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)