### PR TITLE
docs(seo): 6 SEO guideline docs adapted from RooferRate

### DIFF
--- a/docs/SEO_ANCHOR_TEXT_RULES.md
+++ b/docs/SEO_ANCHOR_TEXT_RULES.md
@@ -1,0 +1,111 @@
+# SEO Anchor Text Rules — baltimore.ai
+
+**The rule.** Build a diversified anchor-text profile across all inbound links — internal and external. First link to a destination uses exact-match anchor; subsequent links rotate partial / branded / generic. Track every paid or placed link; let organic anchors be whatever donors choose.
+
+## Target distribution
+
+These ratios are the standard for a healthy backlink profile and apply identically regardless of vertical. Calibrate over your first 20–30 backlinks.
+
+| Anchor type | Share | Example |
+|---|---|---|
+| Exact match | 10–15% | `Baltimore AI companies directory` |
+| Partial match | 35–45% | `this list of Hopkins-affiliated AI startups` |
+| Branded | 25–30% | `baltimore.ai`, `Baltimore.ai` |
+| Generic | 10–20% | `here`, `this directory`, `read more` |
+
+**Exact match dominates → Google's spam classifiers fire.** A 50%+ exact-match profile reads like a paid SEO campaign. The 10–15% target keeps the signal natural.
+
+## Anchor types defined
+
+- **Exact match.** The exact target keyword. Strong ranking signal; sparingly used.
+- **Partial match.** Contains the target keyword but with surrounding words ("the leading Baltimore AI directory").
+- **Branded.** The brand name or domain ("baltimore.ai", "Baltimore.ai").
+- **Generic.** No keyword content ("read this", "here", "this guide").
+
+## First-link / second-link discipline
+
+The first time you (or a partner you can direct) links to a page, use an **exact-match** anchor. The page gets its strongest signal from that first link. After that, **diversify** — never two identical exact-match anchors in a row from the same donor.
+
+```
+Donor A → /companies         link 1: "Baltimore AI companies directory"   (exact)
+Donor A → /companies         link 2: "the curated list at baltimore.ai"   (partial + branded)
+Donor B → /companies         link 1: "AI companies in Baltimore"          (exact)
+Donor C → /companies         link 1: "this directory"                      (generic — fine, low value)
+```
+
+## Priority pages (the link targets that matter)
+
+When you're proposing anchor text for placements you control (guest posts, sponsorships, citation submissions), prioritize these targets in this order:
+
+1. Homepage `/` — anchor: "Baltimore AI companies directory" / "baltimore.ai"
+2. Top category hubs — anchor: "healthcare AI companies in Baltimore", "cybersecurity AI in the Baltimore-DC corridor"
+3. Top guides — anchor: the guide's title or a tighter variant
+4. Specific company pages — only when a donor has a natural reason to link to one company
+
+Don't waste a high-authority external link on a deep, low-traffic page.
+
+## Donor sources
+
+Replace RooferRate's home-improvement / Yelp / BBB donor list with B2B-tech sources.
+
+| Tier | Source | Typical link type |
+|---|---|---|
+| Local press | Technical.ly Baltimore, Baltimore Business Journal, Baltimore Inno | editorial follow |
+| Industry press | The Information, TechCrunch, Axios Local, MIT Tech Review | editorial follow (high value) |
+| Aggregators | Hacker News, Product Hunt | no-follow but high citation value |
+| Tech communities | dev.to, IndieHackers, r/MachineLearning | mixed |
+| Founder/investor lists | AngelList, Crunchbase, F6S, Built In | usually no-follow (citation > link juice) |
+| Academic / institutional | JHU news, UMBC press, FastForward U, TEDCO | follow (high trust) |
+| Personal sites | founder blogs, GitHub READMEs | follow (high relevance) |
+| Newsletters | Tech Council of Maryland, Maryland Tech newsletters | follow |
+
+**No-follow links still matter.** Crunchbase, LinkedIn, AngelList: their no-follow links don't pass PageRank but produce citation signals, referral traffic, and indexing prompts.
+
+## Internal anchor text
+
+The same rules apply inside the app. Internal links from one guide to a company should use descriptive anchors, not "click here":
+
+| Bad | Good |
+|---|---|
+| `read more` | `the Hopkins healthcare AI cluster` |
+| `here` | `Personal Genome Diagnostics` |
+| `this company` | `RedShred's document intelligence platform` |
+
+Existing guide content already follows this (see `db/seeds/guides.rb` — internal links use entity names or descriptive phrases). When writing new guides or category hubs, keep it.
+
+## Track everything
+
+For any link you placed, paid for, or asked for, log it. A simple sheet works:
+
+| Date | Donor URL | Target URL | Anchor text | Type | Follow? | Notes |
+|---|---|---|---|---|---|---|
+| 2026-05-15 | technical.ly/baltimore/launches | baltimore.ai | "Baltimore AI companies directory" | exact | yes | Launch coverage |
+
+After every ~10 placements, compute the distribution. Adjust the next batch toward the target ratios.
+
+## Paid / sponsored placements
+
+If you pay for a link, **verify do-follow** before you sign off. Some publishers default to no-follow on sponsored content; some will flip it on request, others won't.
+
+Disclosure: `rel="sponsored"` on paid links is Google's preference. It still passes signal weight but flags the relationship.
+
+## Dos and don'ts
+
+**Do:**
+- Vary anchor text across donors and across placements from the same donor.
+- Let organic anchors (anything you didn't author) be whatever the donor chose. Even if it's "click here." Don't try to retroactively normalize.
+- Audit periodically. Distribution drifts; rebalance the next batch.
+- Use anchors that match the surrounding content's semantic context.
+
+**Don't:**
+- Don't accept a paid link without verifying follow / sponsored attributes.
+- Don't use two identical exact-match anchors in adjacent paragraphs of the same donor page.
+- Don't anchor "buy AI software" or other commercial-intent stuff to baltimore.ai — it's a directory, not an e-commerce destination, and commercial-intent anchors mismatched to a directory look manipulated.
+- Don't use "Baltimore AI directory listings best top companies machine learning" as one anchor. Keyword-stuffed anchors are the easiest spam pattern for Google to catch.
+
+## RooferRate parallels (for reference)
+
+- The 10-15 / 35-45 / 25-30 / 10-20 ratios are universal — they translate directly with no adjustment.
+- RooferRate's donor list (Yelp, BBB, Angi, home-improvement blogs) → baltimore.ai's donor list (Crunchbase, AngelList, HN, Technical.ly, GitHub, JHU news).
+- The first-link / second-link discipline is identical.
+- The "let organic anchors be whatever" rule is identical.

--- a/docs/SEO_HEADER_RULES.md
+++ b/docs/SEO_HEADER_RULES.md
@@ -1,0 +1,157 @@
+# SEO Header Rules — baltimore.ai
+
+**The rule.** Exactly one H1 per page, containing the primary keyword. H2 and H3 rotate cluster synonyms and affiliation modifiers. UI labels never become headers. The page should make sense when you read only the headers top to bottom.
+
+## The headers-as-story test
+
+Read every H1, H2, H3 on a page in order, ignoring body text. **Does it sound like a coherent outline of what the page covers?** If not, fix the headers — not the body. This is the single best test for whether your headers are doing SEO work or are decorative.
+
+Good (a company page):
+> RedShred · AI-powered document intelligence platform · About RedShred · Similar applied AI companies in Baltimore
+
+Bad (UI labels masquerading as structure):
+> RedShred · Tags · Links · Similar
+
+The bad version's "Tags" / "Links" should be paragraph labels or `<dt>` elements, not headers.
+
+## One H1, always
+
+Every page has exactly one `<h1>`. The H1:
+- Contains the primary keyword from `SEO_KEYWORD_CLUSTERS.md`.
+- Matches (or is a tighter variant of) the `<title>`.
+- Is the largest, most prominent text on the page.
+
+```
+Page              H1 example
+─────────────────────────────────────────────────────────────────
+/                 The directory of AI in Baltimore.
+/companies        AI companies in Baltimore
+/categories/...   Healthcare AI in Baltimore
+/companies/[slug] [Company name]    (the company is the entity)
+/resources/...    [Resource name]
+/guides/...       [Guide title]
+```
+
+## H2 / H3 patterns
+
+H2s break the page into the 3–6 sections a reader scans. H3s subdivide where needed. **Rotate synonyms** across these — every H2 doesn't need the head keyword.
+
+### Homepage (`/`) — pillar pattern
+
+The homepage is the site's pillar page. H1 is the umbrella; H3s are the actual traffic drivers because they target long-tail searches.
+
+```
+H1  The directory of AI in Baltimore.
+H2  Recently added
+H2  Guides
+H3    AI companies in Baltimore: a 2026 field guide
+H3    Healthcare AI in Baltimore: the Hopkins effect
+H3    Cybersecurity AI in the Baltimore-DC corridor
+H2  Categories
+H3    Applied AI · Healthcare AI · AI Consulting · ...
+H2  Labs & resources
+```
+
+### Category hub (`/categories/healthcare_ai`)
+
+```
+H1  Healthcare AI in Baltimore
+H2  Companies                       (the list of orgs)
+H2  Frequently asked                (FAQPage source)
+```
+
+### Company detail (`/companies/[slug]`)
+
+The company *is* the entity, so the company name is the H1. Sub-sections explain attributes.
+
+```
+H1  RedShred
+H2  About RedShred                  (intro paragraph)
+H2  Tags / Links / Founded          ← these are paragraph labels, NOT headers
+H2  Similar applied AI companies in Baltimore
+```
+
+### Guide (`/guides/[slug]`)
+
+The guide title is the H1; H2s and H3s come from the markdown body and should already rotate synonyms naturally because that's how good editorial reads.
+
+```
+H1  AI companies in Baltimore: a 2026 field guide
+H2  The three Baltimore AI scenes
+H3    Healthcare and life-sciences AI
+H3    Cybersecurity AI
+H3    Generalist applied AI and consulting
+H2  What's missing
+H2  Why this matters for hiring
+```
+
+## Synonym rotation
+
+Across a single page's headers, vary how you refer to the entity class. Goal: hit each cluster variant once without it sounding mechanical.
+
+| Entity | Acceptable variants |
+|---|---|
+| AI company | AI company, AI startup, machine learning firm, artificial intelligence company |
+| Research lab | research lab, AI lab, research institute, applied research center |
+| Founder / engineer | founder, AI engineer, researcher, ML engineer, technical lead |
+| Baltimore metro | Baltimore, Baltimore metro, the Baltimore-DC corridor, the I-95 cluster |
+
+**Do not** force four variants into four consecutive headers. Use the one that reads naturally; vary when natural variation is available.
+
+## Use common names, not legal ones
+
+Search behavior favors how people actually talk about an entity.
+
+| Use | Not |
+|---|---|
+| Hopkins APL | The Johns Hopkins University Applied Physics Laboratory |
+| UMBC | University of Maryland, Baltimore County |
+| JHU | The Johns Hopkins University |
+| MINDS | JHU Mathematical Institute for Data, Algorithms, and Decision-making |
+| Tenable | Tenable Holdings, Inc. |
+
+## Demote UI labels to paragraphs
+
+A header should be a heading — a content scaffold. If it's a label for one field, it's not a header.
+
+**Header (correct):**
+> ## Similar applied AI companies in Baltimore
+
+**Label (correct, NOT a header):**
+> **Tags:** Natural Language Processing, Data Platform, Defense & National Security
+
+The current `/companies/[slug]` view follows this rule — `Tags`, `Links`, `Founded`, `Team size`, `Location`, `Website` are styled like labels (small uppercase, neutral color) but are paragraph or `<dt>` elements, not headers.
+
+## Thresholds
+
+| Page type | Reasonable header count |
+|---|---|
+| Homepage | 4–6 H2s, 5–15 H3s (pillar) |
+| Category hub | 2 H2s |
+| Company detail | 2–4 H2s |
+| Resource detail | 1–2 H2s |
+| Guide | 3–6 H2s, 0–10 H3s |
+
+**>20 headers** on any page means you're either oversectioning or treating UI as content.
+
+## Dos and don'ts
+
+**Do:**
+- Run the headers-as-story test before publishing.
+- Use the common name of an entity, not its legal/official name.
+- Let H3s on the homepage carry long-tail keywords.
+- Match H1 to `<title>` (tighter variant OK).
+
+**Don't:**
+- Don't have more than one H1 per page. Modern HTML allows it; Google's understanding still leans on document outline conventions, and the discipline forces clarity.
+- Don't skip levels (H2 → H4). Browsers don't care; readers and screen readers do.
+- Don't put the brand in the H1 ("Baltimore.ai — Healthcare AI in Baltimore"). The brand is in the `<title>` and header chrome.
+- Don't make UI labels into headers.
+- Don't keyword-pack a header. "Best AI companies in Baltimore, MD: top machine learning firms in Maryland 2026" — pick one.
+
+## RooferRate parallels (for reference)
+
+- The pillar pattern (H1 umbrella, H3s as traffic drivers) translates directly. RooferRate uses it on state pages; baltimore.ai uses it on the homepage.
+- The "common name over legal name" rule is identical, only the examples change.
+- The demote-UI-labels rule is identical.
+- "Read headers as a story" test is identical.

--- a/docs/SEO_IMAGE_RULES.md
+++ b/docs/SEO_IMAGE_RULES.md
@@ -1,0 +1,145 @@
+# SEO Image Rules — baltimore.ai
+
+**The rule.** Every image has descriptive, keyword-bearing alt text; is compressed and resized to display dimensions; is named with keywords; is unique per page. Image search is a secondary discovery surface, and social-card images dominate B2B distribution.
+
+## Hard limits
+
+| Property | Limit | Why |
+|---|---|---|
+| File size | ≤100 KB | Mobile users on slow connections; LCP scoring. |
+| Hero / OG width | ~1200px | Display max; anything larger is wasted bytes. |
+| Thumbnail width | 400–800px | Used in listing rows. |
+| OG / Twitter card | exactly 1200×630 | LinkedIn, Twitter, Slack expect this aspect. |
+| Format | WebP preferred, AVIF acceptable | 30–50% smaller than JPEG/PNG, supported everywhere. |
+| Alt text length | ≤125 characters | Screen reader pacing; Google reads more but >125 is rarely useful. |
+
+## Alt text discipline
+
+Alt text serves two readers: screen reader users and Google. Both need a **concrete description** that also happens to include the relevant keyword. Stuffing keywords without describing the image is worse than no alt text.
+
+| Image | Bad alt | Good alt |
+|---|---|---|
+| RedShred founder headshot | `image1.jpg` or `founder` | `RedShred founder at the company's Baltimore office` |
+| Hopkins APL building exterior | `apl building` | `Johns Hopkins APL building in Laurel, MD` |
+| Baltimore Inner Harbor skyline (hero) | `baltimore` or `city` | `Baltimore Inner Harbor at sunset — home to the city's AI cluster` |
+| Company logo | `logo` | `RedShred logo` |
+| Decorative pattern (no content) | `decorative pattern` | `""` (empty alt — see below) |
+
+**Decorative images get `alt=""`.** Empty alt tells screen readers to skip; missing alt makes them read the filename. Always set one or the other.
+
+## Filename conventions
+
+Filenames are a weak signal but they're free. Use kebab-case, keyword-bearing names.
+
+```
+✓  redshred-logo.webp
+✓  hopkins-apl-baltimore.webp
+✓  baltimore-ai-companies-2026-hero.webp
+
+✗  IMG_2847.jpg
+✗  image-final-v2-USE-THIS.png
+✗  logo.png  (in a directory with 30 logos)
+```
+
+## Image inventory by page type
+
+| Page | Images needed | Notes |
+|---|---|---|
+| Homepage `/` | OG card (1200×630), favicon | OG is critical — most launch traffic comes from social. |
+| `/companies/[slug]` | Logo (square, ≥400×400), OG card, optional team/office photo | Logo from company press kit; OG card auto-generated from logo + name. |
+| `/categories/[slug]` | OG card | Auto-generated; vertical name + count. |
+| `/resources/[slug]` | Logo / building photo | JHU, UMBC, FastForward provide press kits. |
+| `/guides/[slug]` | OG card (1200×630), optional hero | Custom hero for guides we want to promote; OG card always required. |
+
+## OG / social cards — the most important image you'll make
+
+**B2B distribution is LinkedIn-heavy.** Every public page's OG image is what 90% of clicks see first. Standards:
+
+- **Exact dimensions: 1200×630.** Off-spec sizes get cropped weirdly on different platforms.
+- **Text-safe zone: center 1000×500.** LinkedIn and Twitter crop the edges on some layouts.
+- **Readable at 600×315.** Phone previews shrink it. If the text is unreadable there, it's wrong.
+- **Brand mark in a consistent corner.** Bottom-left works. Same place on every card.
+- **High contrast.** Dark text on light bg or vice versa. No "white text on a busy photo."
+
+```
+Template for a company OG card:
+
+  ┌──────────────────────────────────────────────────┐
+  │                                                  │
+  │   RedShred                          Baltimore.ai │
+  │                                                  │
+  │   AI-powered document intelligence               │
+  │                                                  │
+  │                                                  │
+  │   APPLIED AI · BALTIMORE · FOUNDED 2014          │
+  │                                                  │
+  └──────────────────────────────────────────────────┘
+```
+
+We don't have automated OG card generation yet (TODO post-launch — use `og:image` defaults to the favicon for now). When implemented, generate at request time and cache to Active Storage.
+
+## Source images responsibly
+
+| Source | Use case | Caveats |
+|---|---|---|
+| Company press kits | Logos, team photos | Always preferred; companies expect to be listed. |
+| Founder LinkedIn (public) | Headshots for guides | Only with attribution and only for editorial use. |
+| Unsplash / Pexels | Stock for guides | Vet for AI-aesthetic clichés — neon hands holding holograms is a no. |
+| Self-generated | Diagrams, illustrations, OG cards | Best long-term — distinctive and never DMCA-able. |
+| AI-generated (Imagen, DALL-E) | Sparingly, for guides | Disclose in alt text. Risk of generic AI look. |
+
+**Never use:**
+- Watermarked stock photos.
+- Photos from a company without their permission for editorial use (e.g. scraped from their site for our guide).
+- Anything from a Google Images result without clearing the source.
+
+## Lazy load below the fold
+
+Native HTML attribute, no JS required:
+
+```html
+<img src="..." alt="..." loading="lazy" decoding="async" width="..." height="...">
+```
+
+**Always include `width` and `height` attributes** — even when CSS-sizing the image. They prevent CLS (Cumulative Layout Shift) on slow connections. Rails' `image_tag` helper accepts both.
+
+## Uniqueness
+
+Don't reuse the same hero image across multiple pages. Google's image-deduplication treats reused images as low-value. If you only have one hero photo, crop/recompose for each page.
+
+The exception: small icons (chevrons, social-platform marks) are fine reused everywhere. The rule is about **content images**.
+
+## Implementation status
+
+| Rule | Current state | TODO |
+|---|---|---|
+| Alt text discipline | No images shipped yet | Apply when adding logos/OG cards |
+| OG card generation | Falls through to favicon | Build OG-card generator service post-launch |
+| WebP format | N/A | Use WebP for all new images |
+| Lazy loading | N/A | Apply when adding images |
+| Filename convention | N/A | Apply when adding images |
+
+When we add the first logos (probably as part of company claim flow letting owners upload one), Active Storage variants should be configured to generate WebP at appropriate sizes. The `image_processing` gem is already in the Gemfile.
+
+## Dos and don'ts
+
+**Do:**
+- Write alt text that would tell someone over the phone what the image shows.
+- Resize to display dimensions before upload — never serve a 4000px image scaled down by CSS.
+- Use a consistent visual tone across all OG cards. Same font, same brand mark placement.
+- Test OG cards using LinkedIn Post Inspector, Twitter's Card Validator.
+
+**Don't:**
+- Don't leave images without `width` and `height` — CLS will tank Core Web Vitals.
+- Don't ship a single image >100 KB without a deliberate reason. Even hero photos compress to ~80 KB at WebP quality 80.
+- Don't keyword-stuff alt text. "Baltimore AI companies machine learning artificial intelligence directory image" is a no.
+- Don't use the same photo on two pages and call it "unique because the alt text is different."
+- Don't use AI-generated images for hero or OG without human review. Six-fingered hands and uncanny gradients destroy trust.
+
+## RooferRate parallels (for reference)
+
+- All format, compression, alt-text, filename, lazy-load, watermark, and uniqueness rules translate directly.
+- RooferRate's "before/after project photos" → product screenshots, demo GIFs, architecture diagrams.
+- RooferRate's "contractor truck / certification badges" → company logo + funding/accelerator badges (YC, NSF, TEDCO).
+- RooferRate's "encourage contractors to upload during claim" → baltimore.ai's claim flow should accept logo + (optional) team photo. Not implemented yet.
+- New on baltimore.ai: dedicated OG / social-card emphasis (1200×630). RooferRate's traffic is primarily Google Search and Maps; baltimore.ai's launch traffic is heavily LinkedIn/Twitter.

--- a/docs/SEO_KEYWORD_CLUSTERS.md
+++ b/docs/SEO_KEYWORD_CLUSTERS.md
@@ -1,0 +1,134 @@
+# SEO Keyword Clusters — baltimore.ai
+
+**Adapted from RooferRate's keyword cluster framework.** baltimore.ai is a single-metro, B2B-skewed directory of AI companies, research labs, and resources. That changes the cluster shape: there's no multi-city geo dimension to scale, and the "service" axis becomes AI vertical / capability.
+
+## The rule
+
+Define a primary keyword cluster (synonyms for the same intent), then layer secondary axes — affiliation, vertical, capability, intent — rotating naturally and never stuffing. **One primary keyword per page.** Body copy uses ≥3 cluster variations naturally.
+
+## Cluster axes
+
+### 1. Primary cluster — the head query
+
+This is the query baltimore.ai must own. Synonyms rotate at H2 / H3 / body level.
+
+- AI companies in Baltimore
+- Baltimore AI companies
+- Baltimore artificial intelligence companies
+- AI startups in Baltimore
+- machine learning companies Baltimore
+- Baltimore AI directory
+- AI companies near Baltimore
+
+Branded variants:
+- baltimore.ai
+- the Baltimore AI directory
+
+### 2. Affiliation cluster — Baltimore-specific entities
+
+This replaces RooferRate's geo-city cluster. Affiliation modifiers carry trust and produce unique long-tail combinations Google rewards.
+
+- Johns Hopkins AI / Hopkins AI startups
+- Hopkins APL spinouts / APL AI research
+- JHU AI Institute / JHU MINDS
+- UMBC AI / UMBC machine learning
+- bwtech AI companies / bwtech@UMBC AI
+- FastForward U AI
+- TEDCO AI portfolio
+- Fort Meade AI / Maryland defense AI
+- Baltimore-DC corridor AI
+
+### 3. Vertical cluster — what kind of AI
+
+Replaces RooferRate's "service type" cluster. Each company maps to one primary vertical; pages target one vertical at a time.
+
+- healthcare AI Baltimore
+- defense AI Maryland
+- cybersecurity AI Baltimore
+- AI consulting Baltimore
+- biotech AI Baltimore
+- generative AI Baltimore
+- enterprise AI Baltimore
+- AI infrastructure Baltimore
+- robotics Baltimore
+- govtech AI Baltimore
+- edtech AI Baltimore
+
+### 4. Capability / tech cluster — how the AI works
+
+Replaces RooferRate's "material" cluster. Long-tail, lower competition, high intent.
+
+- LLM companies Baltimore
+- computer vision Baltimore
+- NLP companies Baltimore
+- MLOps Baltimore
+- vector database Baltimore
+- agentic AI Baltimore
+- foundation models Baltimore
+- AI inference / model serving Baltimore
+- RAG vendors Baltimore
+
+### 5. Intent cluster — buyer / job-seeker / founder queries
+
+This is where buyers, recruits, and founders enter the funnel.
+
+- AI consultants Baltimore
+- hire an AI engineer Baltimore
+- Baltimore AI jobs
+- AI internships Baltimore
+- Baltimore AI accelerator
+- AI grant Maryland
+- pitch competition AI Baltimore
+- AI hackathon Baltimore
+
+### 6. Content cluster — guide / explainer queries
+
+Editorial pages (`/guides/*`) target these. Always include the year on guide titles.
+
+- best AI companies Baltimore 2026
+- top healthcare AI companies Baltimore
+- how to choose an AI consultant Baltimore
+- AI salary Baltimore
+- where to learn AI Baltimore
+- Baltimore AI ecosystem report
+
+## Mapping clusters → page types
+
+| Page type | Primary cluster slot | Secondary mix |
+|---|---|---|
+| Homepage `/` | "Baltimore AI companies & labs directory" | affiliation, vertical |
+| Category `/categories/healthcare_ai` | "healthcare AI Baltimore" | affiliation, capability |
+| Company `/companies/[slug]` | "[Company] — Baltimore [vertical] company" | affiliation, capability |
+| Resource `/resources/[slug]` | "[Resource]" | affiliation, intent |
+| Guide `/guides/[slug]` | content cluster phrase (with year) | primary, vertical |
+
+## Dos and don'ts
+
+**Do:**
+- Use ≥3 cluster variations per page, distributed across title / H1 / H2 / body.
+- One primary keyword per page. If a page is trying to rank for two head queries, split it.
+- Rotate synonyms aggressively. "AI company" → "AI startup" → "machine learning firm" → "artificial intelligence company".
+- Cross-link guide pages to ≥2 directory entries (company or resource) with descriptive anchor text.
+- Front-load the primary keyword in title and H1.
+
+**Don't:**
+- Don't repeat the exact same phrase 6 times on one page. That's stuffing.
+- Don't combine two head queries in one title ("Baltimore AI companies and healthcare AI" — pick one).
+- Don't target a vertical that has fewer than 3 entities (noindex the page, see SEO_TRUST_AND_POLISH).
+- Don't use vague filler ("technology company", "innovative AI") — Google's classifier flags it.
+
+## Quantitative thresholds
+
+| Rule | Threshold |
+|---|---|
+| Cluster variations per page (in body) | ≥3 |
+| Primary keyword mentions in body | 3–5 |
+| Internal links from guide → directory pages | ≥2 |
+| Pages per facet to publish (else noindex) | ≥3 entities |
+
+## RooferRate parallels (for reference)
+
+- The geo-city dimension in RooferRate's docs (`roofers in [city]`) **does not apply** here — baltimore.ai is single-metro.
+- RooferRate's "material cluster" (asphalt, metal, slate) → "capability cluster" (LLM, computer vision, NLP) on baltimore.ai.
+- RooferRate's "service cluster" (repair, replacement, inspection) → "vertical cluster" (healthcare AI, cybersecurity AI, etc.).
+- RooferRate's trust modifiers ("licensed", "insured") → affiliation modifiers ("Hopkins-affiliated", "APL spinout", "Y Combinator-backed").

--- a/docs/SEO_META_RULES.md
+++ b/docs/SEO_META_RULES.md
@@ -1,0 +1,92 @@
+# SEO Meta Rules — baltimore.ai
+
+**The rule.** Every page has a unique meta title ≤60 characters with the primary keyword front-loaded and the brand last; meta description ≤160 characters, written for click-through, with one trust signal. Title and H1 match — no surprises.
+
+## Hard limits
+
+| Element | Max length | Why |
+|---|---|---|
+| `<title>` | 60 chars | Google truncates around 580px wide; 60 chars is a safe ceiling. |
+| Meta description | 160 chars | Truncates around 160 desktop / 120 mobile. Lead with the most important 120. |
+| OG title | 60 chars | Same as `<title>`. Layouts above the fold rarely show more. |
+| OG description | 160 chars | LinkedIn/Twitter card previews truncate near 160. |
+
+## Title formulas by page type
+
+The brand is `Baltimore.ai` — short, distinct, doubles as the URL. **Always last**, separated by `·`.
+
+| Page | Formula | Example |
+|---|---|---|
+| Homepage `/` | `[Primary keyword] · Baltimore.ai` | `AI companies in Baltimore · Baltimore.ai` |
+| Companies index `/companies` | `AI companies in Baltimore · Baltimore.ai` | (same) |
+| Category `/categories/[slug]` | `[Vertical] in Baltimore · Baltimore.ai` | `Healthcare AI in Baltimore · Baltimore.ai` |
+| Company `/companies/[slug]` | `[Company] · Baltimore AI directory · Baltimore.ai` | `RedShred · Baltimore AI directory · Baltimore.ai` |
+| Resource `/resources/[slug]` | `[Resource] · Baltimore.ai` | `Johns Hopkins APL · Baltimore.ai` |
+| Resources index `/resources` | `Baltimore AI labs & resources · Baltimore.ai` | (same) |
+| Guide `/guides/[slug]` | `[Guide title] (YYYY) · Baltimore.ai` | `AI companies in Baltimore (2026) · Baltimore.ai` |
+| Guides index `/guides` | `Guides to AI in Baltimore · Baltimore.ai` | (same) |
+
+**The year on guide titles is non-optional.** "(2026)" tells users it's fresh and lets Google index dated-search variants ("ai companies baltimore 2026").
+
+## Meta description formulas
+
+Lead with concrete numbers (company counts, year). End with an action or hook. **No filler.**
+
+| Page | Formula |
+|---|---|
+| Homepage | `A curated directory of {N} AI companies, research labs, and resources in the Baltimore metro.` |
+| Category hub | `{N} Baltimore-area AI companies in {vertical} — including {top 3 names}.` |
+| Company | `{Company tagline}. Founded {year}, based in Baltimore. Part of the Baltimore.ai directory.` (or company-supplied) |
+| Resource | `{Resource} — a {type} supporting AI work in Baltimore.` (or resource-supplied) |
+| Guide | First 160 chars of the guide intro, hand-edited if needed for a strong CTA. |
+
+## Implementation in the app
+
+These rules are already enforced in code. Reference points:
+
+- `app/views/layouts/application.html.erb` — sets defaults via `content_for :title` and `content_for :meta_description`, plus canonical URL.
+- `app/helpers/application_helper.rb#page_title` — joins parts with `·` and appends `Baltimore.ai`.
+- Each view's first two lines override per-page values.
+
+When adding a new page type, follow that pattern. **Never let a page fall through to the layout default title** — that's how duplicate-title penalties happen.
+
+## Canonical URLs
+
+- One canonical URL per page. Defined in the layout from `request.path`.
+- No `?utm_*` indexed variants. Strip tracking parameters at the canonical level.
+- Slugs are flat, kebab-case, no category prefix (a company can span verticals; the URL shouldn't churn when categorization shifts).
+
+## Uniqueness audit
+
+Every published page must have a unique `<title>` and unique meta description. Quick check:
+
+```bash
+# After deploy, run from local:
+for slug in $(bin/rails runner 'puts Company.published.pluck(:slug)'); do
+  curl -sS "https://baltimore.ai/companies/$slug" | grep -oE '<title>[^<]+</title>'
+done | sort | uniq -d
+```
+
+If anything appears, fix before broad outreach.
+
+## Dos and don'ts
+
+**Do:**
+- Match `<title>` exactly to the H1 (or to a tighter variant of it).
+- Front-load the primary keyword.
+- Use `·` as the separator. Consistent visual identity in SERPs.
+- Templatize per page type — never hand-author a one-off.
+- Add the year to guide and category titles when content is dated.
+
+**Don't:**
+- Don't include `MD` or `Maryland` in titles. The `.ai` brand telegraphs Baltimore; those characters are better spent on a vertical or affiliation word.
+- Don't duplicate titles across pages. A category page and its lone company page must not share a title.
+- Don't put the brand first. `Baltimore.ai — AI companies in Baltimore` wastes the most valuable real estate on a known brand.
+- Don't keyword-stuff descriptions ("AI Baltimore best top companies firms machine learning"). Read aloud — if it sounds like a phishing email, rewrite.
+- Don't emoji-pad titles for CTR. Looks spammy in SERPs and inconsistent across devices.
+
+## RooferRate parallels (for reference)
+
+- RooferRate appends state abbreviations (`MD`, `VA`) to titles for multi-state distinction. baltimore.ai doesn't — single-metro, brand telegraphs location.
+- RooferRate's per-page-type formulas translate directly; only the noun changes ("roofer" → "AI company").
+- RooferRate's "(2026)" year-tag rule on cost guides applies identically to baltimore.ai's editorial guides.

--- a/docs/SEO_README.md
+++ b/docs/SEO_README.md
@@ -1,0 +1,85 @@
+# SEO Guidelines for baltimore.ai
+
+The 6 docs in this set translate RooferRate's SEO playbook to baltimore.ai's context: a single-metro, B2B-skewed directory of AI companies, research labs, and resources. Most rules transfer directly (and have ratios/limits worth treating as universal); some need adaptation for AI/B2B.
+
+## The six docs
+
+| File | What it covers | When to read it |
+|---|---|---|
+| [SEO_KEYWORD_CLUSTERS.md](SEO_KEYWORD_CLUSTERS.md) | Primary, affiliation, vertical, capability, intent, content clusters. Mapping pages → clusters. | Before writing a new page or guide. |
+| [SEO_META_RULES.md](SEO_META_RULES.md) | `<title>` and meta description formulas per page type. Char limits. Canonical URLs. | When adding a new page type or auditing for duplicates. |
+| [SEO_HEADER_RULES.md](SEO_HEADER_RULES.md) | One H1 rule. Headers-as-story test. Pillar page pattern. | When writing or editing a guide; when adding a new view. |
+| [SEO_ANCHOR_TEXT_RULES.md](SEO_ANCHOR_TEXT_RULES.md) | 10/40/30/15 anchor distribution. Donor sources. Internal anchor discipline. | Before placing or paying for any inbound link. |
+| [SEO_IMAGE_RULES.md](SEO_IMAGE_RULES.md) | Alt text, compression, filenames, OG cards (1200×630). | When adding any image, especially OG cards. |
+| [SEO_TRUST_AND_POLISH.md](SEO_TRUST_AND_POLISH.md) | Foundational pages, schema-by-page, FAQ rules, E-E-A-T checklist, Core Web Vitals targets. | Pre-launch checklist; quarterly audit. |
+
+## What changed from RooferRate
+
+| Translates directly | Adapted | Dropped |
+|---|---|---|
+| Header rules (entire doc) | Geo cluster (single-metro now) | Multi-state expansion |
+| Anchor text ratios | Trust signals (license → affiliation) | Click-to-call as primary CTA |
+| Meta char limits + formulas | Schema types (`LocalBusiness` → `Organization`) | MHIC license framing |
+| Image format + compression | Mobile traffic assumption (80% → 50%) | Emergency / 24-7 service intent |
+| Foundational pages list | Donor sources (home improvement → tech press) | |
+
+## The most important rules (TL;DR)
+
+1. **One primary keyword per page** (keyword clusters doc).
+2. **`<title>` ≤60 chars, meta description ≤160, brand last** (meta doc).
+3. **One H1 per page; read your headers top to bottom — they should tell a story** (header doc).
+4. **First link to a page uses exact-match anchor; diversify after** (anchor doc).
+5. **Every image gets descriptive alt text and is ≤100 KB** (image doc).
+6. **Ship the About page with a real person's name before broad outreach** (trust doc).
+
+## Implementation status
+
+What's already wired into code (verified at deploy time):
+
+- ✅ Per-page `<title>` and meta description (`app/views/layouts/application.html.erb`)
+- ✅ Canonical URLs
+- ✅ Open Graph + Twitter Card tags
+- ✅ Organization / WebSite / BreadcrumbList / ItemList / FAQPage / Article JSON-LD
+- ✅ Sitemap.xml with thin-facet filter (≥3 entities to index)
+- ✅ Robots.txt
+- ✅ Single H1 per page; descriptive H2/H3
+- ✅ Internal anchor text uses entity names, not "click here"
+
+What's still TODO (tracked in [LAUNCH.md](LAUNCH.md)):
+
+- ⏳ About / Contact / How It Works / Editorial Standards / Privacy / Terms pages
+- ⏳ OG card generator (1200×630 per listing)
+- ⏳ Logos on company listings (via claim flow)
+- ⏳ Last-verified date display
+- ⏳ GSC + Bing verification
+- ⏳ Citation submissions
+- ⏳ Outreach to top 10 seeded companies
+
+## Auditing
+
+Before any broad outreach push, run through this short audit:
+
+```bash
+# Duplicate title check
+for slug in $(bin/rails runner 'puts Company.published.pluck(:slug)'); do
+  curl -sS "https://baltimore.ai/companies/$slug" | grep -oE '<title>[^<]+</title>'
+done | sort | uniq -d
+# Should produce no output.
+
+# JSON-LD validation
+# Visit https://search.google.com/test/rich-results and test:
+#   https://baltimore.ai/
+#   https://baltimore.ai/companies/redshred
+#   https://baltimore.ai/categories/healthcare_ai
+#   https://baltimore.ai/guides/ai-companies-baltimore-2026
+# All should pass with no errors.
+
+# Sitemap validity
+curl -sS https://baltimore.ai/sitemap.xml.gz | gunzip | xmllint --noout - && echo OK
+
+# Core Web Vitals
+# Run https://pagespeed.web.dev/ on the homepage + 1 company + 1 guide.
+# All three should be in the "Good" range.
+```
+
+If any of those fail, fix before promoting the site.

--- a/docs/SEO_TRUST_AND_POLISH.md
+++ b/docs/SEO_TRUST_AND_POLISH.md
@@ -1,0 +1,171 @@
+# SEO Trust & Polish — baltimore.ai
+
+**The rule.** Every public page is responsive (B2B traffic skews desktop), uses structured data correctly, has the foundational pages search engines and skeptics look for, and demonstrates E-E-A-T (experience, expertise, authoritativeness, trustworthiness) through real attribution.
+
+This doc adapts RooferRate's `SEO_TRUST_MOBILE_POLISH.md` for an AI/B2B context. The biggest changes: traffic isn't 80% mobile, click-to-call isn't the primary CTA, and the trust signals are fundamentally different (no MHIC license to verify — instead, funding, affiliation, security certifications).
+
+## Traffic assumption
+
+| Audience | Approximate device split |
+|---|---|
+| Engineers, founders, recruiters | 55–65% desktop |
+| Researchers (academic-side) | 60–70% desktop |
+| Local press, citation submitters | 50/50 |
+
+**Plan for ~50/50** — responsive across breakpoints, no "mobile-first" framing that gates desktop affordances. This is the opposite of RooferRate's assumption.
+
+## Foundational pages (TODO — not yet built)
+
+A directory that doesn't have these reads as unfinished and ranks worse. Build these before any broad outreach:
+
+- [ ] `/about` — what baltimore.ai is, who runs it, how listings are curated. Must name a real person/company (E-E-A-T).
+- [ ] `/contact` — at minimum, an email. Optionally a contact form that creates an admin notification.
+- [ ] `/how-it-works` — explains the claim/verify flow, moderation, what gets listed.
+- [ ] `/editorial-standards` — how curated entries are written, what triggers a manual review, where the editorial line is drawn.
+- [ ] `/privacy` — minimal but real privacy policy. Required for Google's trust signals and basic compliance.
+- [ ] `/terms` — terms of use. Same.
+
+Layout chrome (header + footer) should link to all six.
+
+## Schema-by-page-type
+
+Three layers per page (already implemented):
+
+| Page | Site graph (always) | Page-specific |
+|---|---|---|
+| Home `/` | Organization + WebSite | (none extra) |
+| `/companies` | site graph | `ItemList` + `BreadcrumbList` |
+| `/companies/[slug]` | site graph | `Organization` (the company) + `BreadcrumbList` |
+| `/categories` | site graph | `BreadcrumbList` |
+| `/categories/[slug]` | site graph | `ItemList` + `BreadcrumbList` + `FAQPage` |
+| `/resources` | site graph | `BreadcrumbList` |
+| `/resources/[slug]` | site graph | `Organization` (the resource) + `BreadcrumbList` |
+| `/guides` | site graph | `BreadcrumbList` |
+| `/guides/[slug]` | site graph | `Article` + `BreadcrumbList` |
+
+**Do not use `LocalBusiness`** for AI companies, even though it superficially fits. Google's 2026 docs explicitly flag misuse of `LocalBusiness` for non-storefront orgs. Use `Organization` (or a specific subtype like `SoftwareApplication`, `ResearchOrganization`) instead. The current implementation gets this right.
+
+**Validate after deploy.** Use [Google's Rich Results Test](https://search.google.com/test/rich-results) on:
+- `/` — Organization + WebSite
+- `/companies/redshred` — Organization
+- `/companies` — ItemList
+- `/categories/healthcare_ai` — FAQPage + ItemList
+- `/guides/ai-companies-baltimore-2026` — Article
+
+All five should pass at deploy time.
+
+## FAQ pages
+
+Currently implemented on category hubs (`app/views/categories/show.html.erb`). Rules:
+
+- 3–5 questions per page. Fewer feels thin; more reads like SEO bait.
+- Questions are unique per page. Don't reuse the same FAQ across multiple categories.
+- Answers are real and useful. "How many AI companies are in Baltimore?" → an actual count, not boilerplate.
+- Visible to users AND emitted as `FAQPage` JSON-LD. Hidden-only FAQ is a Google policy violation.
+
+When adding FAQs to other page types (homepage, About, How It Works), follow the same rules.
+
+## Trust signals — the AI/B2B substitution
+
+RooferRate trusts contractors by surfacing licenses, insurance, and BBB ratings. Those are wrong here. The equivalents:
+
+| RooferRate (don't use) | baltimore.ai equivalent |
+|---|---|
+| MHIC license number | YC / TechStars / FastForward / TEDCO badge |
+| Liability insurance | Funding round (Series A, etc.) with date |
+| BBB rating | GitHub stars, arxiv citations, NSF grants |
+| Years in business | Founding year + last_verified_at |
+| Customer reviews | Press mentions (Technical.ly, BBJ, TechCrunch) |
+| Service area map | "Baltimore-headquartered" / "Hopkins APL spinout" — affiliation |
+
+When the claim flow lets companies upload enrichment data (post-launch), make these fields first-class on the company detail page. Until then, the editorial blurb carries the trust signal.
+
+**Show `last_verified_at` on the page.** "Verified by RedShred · May 2026" tells users (and Google) the info is current.
+
+## Foundational page templates
+
+Quick sketches for the missing foundational pages. Build these as Rails views; no need for a CMS.
+
+### /about — must mention a real person
+
+> **Baltimore.ai is a directory of AI companies, research labs, and resources in the Baltimore metro.**
+>
+> Built and curated by [Justus Eapen](https://justuseapen.com), who has worked in Baltimore tech for [...] years and watched the AI scene grow up around Hopkins APL, UMBC, and the I-95 corridor. Editorial entries are written by hand; companies can claim and edit their own listings via the [claim flow](/sign-in).
+>
+> Have a correction or want to be listed? [Contact us](/contact).
+
+This is the most important page for E-E-A-T. Without a named person and a real-sounding bio, the site reads as low-trust.
+
+### /how-it-works
+
+> 1. **Curated to start.** Every listing starts as an editorial entry written from public information.
+> 2. **Claim your listing.** Companies can claim an entry by verifying an email at the company's domain. Auto-approves when the email and website domain match; otherwise routes to manual review.
+> 3. **Edit anytime.** After claiming, you sign in with a magic link to edit your own listing.
+> 4. **Moderation.** Manual-review claims are approved within 7 days. Stale claims auto-reject after 30.
+
+### /editorial-standards
+
+> - Listings cover companies based in or with significant operations in the Baltimore metro.
+> - "Significant presence" means a real office, leadership in the region, or a substantive multi-year program tie. Distributed-team-with-one-Baltimore-engineer doesn't count.
+> - Editorial blurbs are written by hand; we don't auto-generate company descriptions.
+> - Funding, headcount, and founding year are sourced from public records (Crunchbase, SEC filings, official company sites) and verified at last-verified date shown on the listing.
+> - When in doubt, we err toward not listing.
+
+This is what credibility looks like. Six paragraphs is enough.
+
+## Click intent — what the page asks users to do
+
+| Page | Primary CTA | NOT this |
+|---|---|---|
+| Homepage | "Browse companies" | "Get a free quote" / "Call now" |
+| Company detail | "Visit website" (outbound) or "Claim listing" (for unclaimed) | "Call this company" |
+| Guide | Internal link to next guide or category | (no commercial CTA) |
+| Category hub | "Browse [vertical] companies" | (none) |
+
+Click-to-call (`tel:` links) is the wrong primary CTA for AI-vendor discovery. Click-to-website ("Visit redshred.com") and click-to-claim are the right primary actions.
+
+## Mobile tap targets (still apply, just less central)
+
+When a button or link must be tappable on mobile:
+
+- Min 44×44 px hit area (Apple HIG; Android material design agrees).
+- 8px spacing between adjacent tap targets.
+- Sufficient color contrast (WCAG AA: 4.5:1 for body, 3:1 for large text).
+
+The current Tailwind styles meet these defaults; spot-check after design changes.
+
+## E-E-A-T checklist
+
+Google's E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness) factors. For a niche directory:
+
+| Factor | How baltimore.ai signals it |
+|---|---|
+| Experience | Editorial guides written from first-hand Baltimore tech experience (named author on About) |
+| Expertise | Specific, opinionated guides (`healthcare-ai-baltimore-hopkins.md`) — not generic content |
+| Authoritativeness | Inbound citations from Technical.ly, BBJ, EAGB, GBC (per LAUNCH.md) |
+| Trustworthiness | About + Editorial Standards + named curator + claim flow audit trail |
+
+The single highest-leverage move for E-E-A-T is **shipping the About page with a real person's name and credentials.**
+
+## Performance & Core Web Vitals
+
+Targets that pass Google's "good" thresholds:
+
+| Metric | Target |
+|---|---|
+| LCP (Largest Contentful Paint) | < 2.5s |
+| INP (Interaction to Next Paint) | < 200ms |
+| CLS (Cumulative Layout Shift) | < 0.1 |
+| Page weight | < 200 KB excluding images |
+
+Current implementation: server-rendered Rails + Tailwind, importmap-rails (no bundler), very small JS surface. Should pass Web Vitals comfortably. **Verify with [PageSpeed Insights](https://pagespeed.web.dev/) on the live URL** after the next round of design changes.
+
+## RooferRate parallels (for reference)
+
+- The foundational-pages list is identical (About, Contact, How It Works, Privacy, Terms).
+- The breadcrumbs + JSON-LD schema discipline translates directly. Schema *types* shift (`LocalBusiness` → `Organization`).
+- FAQPage rules are identical.
+- 80–85% mobile assumption is **inverted** — B2B skews desktop. Adjust mental model.
+- Click-to-call CTA is **replaced** with click-to-website / click-to-claim.
+- License/insurance trust modifiers are **replaced** with funding/affiliation/security-cert modifiers.
+- "About page must name a real person" rule is identical and more important here, not less.

--- a/fly.toml
+++ b/fly.toml
@@ -16,7 +16,7 @@ primary_region = "iad"
   release_command = "./bin/rails db:prepare"
 
 [env]
-  PORT = "8080"
+  HTTP_PORT = "8080"
   RAILS_LOG_TO_STDOUT = "true"
   RAILS_SERVE_STATIC_FILES = "true"
   APP_HOST = "https://baltimore.ai"


### PR DESCRIPTION
## Summary

Ports RooferRate's 6-doc SEO playbook to baltimore.ai, adapted for our single-metro, B2B-skewed directory context.

**New docs in \`docs/\`:**
- \`SEO_README.md\` — index, TL;DR rules, audit commands
- \`SEO_KEYWORD_CLUSTERS.md\` — primary, affiliation, vertical, capability, intent, content
- \`SEO_META_RULES.md\` — 60/160 char limits, per-page-type formulas
- \`SEO_HEADER_RULES.md\` — one-H1 rule, headers-as-story test, pillar pattern
- \`SEO_ANCHOR_TEXT_RULES.md\` — 10/40/30/15 anchor distribution, donor sources
- \`SEO_IMAGE_RULES.md\` — alt text, compression, OG cards (1200×630)
- \`SEO_TRUST_AND_POLISH.md\` — foundational pages, schema-by-page, E-E-A-T

Each doc closes with explicit RooferRate→baltimore.ai parallels.

**Also includes:** the \`fly.toml\` HTTP_PORT fix that's been live in production since the deploy session but never made it to git. Catching it up.

## Honest flags

- These are guidelines, not implementations. The implementation status section in \`SEO_README.md\` shows what's wired vs. TODO.
- Most SEO infrastructure (JSON-LD, canonicals, sitemap, thin-facet filter, FAQPage) is already in production from Phase 1-4. The docs codify the rules going forward.
- Open TODOs surfaced: About / Contact / How It Works / Editorial Standards pages, OG card generator, last-verified date display, logos via claim flow.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: docs-only change, no production impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)