### PR TITLE
chore(mail): switch SMTP defaults from Postmark to Resend

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,19 +60,22 @@ Rails.application.configure do
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST_NAME", "baltimore.ai"), protocol: "https" }
 
-  # SMTP via env vars — defaults to Postmark.
-  # Required env vars when SMTP_USERNAME/SMTP_PASSWORD are set:
-  #   SMTP_ADDRESS (default: smtp.postmarkapp.com)
-  #   SMTP_PORT    (default: 587)
-  #   SMTP_USERNAME, SMTP_PASSWORD
-  if ENV["SMTP_USERNAME"].present?
+  # SMTP via env vars — defaults to Resend.
+  # See docs/RESEND_SETUP.md for the full setup walkthrough.
+  # Required env vars when SMTP_PASSWORD is set:
+  #   SMTP_PASSWORD — Resend API key (re_...)
+  # Optional (have sensible defaults):
+  #   SMTP_ADDRESS  (default: smtp.resend.com)
+  #   SMTP_PORT     (default: 587 — STARTTLS)
+  #   SMTP_USERNAME (default: "resend" — Resend's literal SMTP username)
+  if ENV["SMTP_PASSWORD"].present?
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_deliveries = true
     config.action_mailer.raise_delivery_errors = true
     config.action_mailer.smtp_settings = {
-      address: ENV.fetch("SMTP_ADDRESS", "smtp.postmarkapp.com"),
+      address: ENV.fetch("SMTP_ADDRESS", "smtp.resend.com"),
       port: ENV.fetch("SMTP_PORT", 587).to_i,
-      user_name: ENV["SMTP_USERNAME"],
+      user_name: ENV.fetch("SMTP_USERNAME", "resend"),
       password: ENV["SMTP_PASSWORD"],
       authentication: :plain,
       enable_starttls_auto: true

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -17,14 +17,11 @@ fly secrets set APP_HOST_NAME=baltimore.ai
 fly secrets set MAIL_FROM="Baltimore.ai <hello@baltimore.ai>"
 fly secrets set ADMIN_EMAIL=you@yourdomain.com
 
-# 4. Configure outbound email (Postmark)
-#    a. Sign up at postmarkapp.com
-#    b. Verify the baltimore.ai sender domain (DKIM + Return-Path DNS records)
-#    c. Generate a server token; that's the SMTP password
-fly secrets set SMTP_USERNAME=<postmark-server-token> SMTP_PASSWORD=<same-token>
-# Optional, defaults to Postmark:
-#   SMTP_ADDRESS=smtp.postmarkapp.com
-#   SMTP_PORT=587
+# 4. Configure outbound email (Resend)
+#    See docs/RESEND_SETUP.md for the full walkthrough.
+#    Short version: resend.com → verify baltimore.ai sender domain
+#    (add SPF + DKIM DNS records) → create an API key → set as SMTP_PASSWORD.
+fly secrets set SMTP_PASSWORD=re_xxxxxxxxxxxxxxxxxxxxxxx
 
 # 5. Deploy
 fly deploy

--- a/docs/RESEND_SETUP.md
+++ b/docs/RESEND_SETUP.md
@@ -1,0 +1,96 @@
+# Resend setup for baltimore.ai
+
+End-to-end setup for production transactional email via [Resend](https://resend.com). ~15 minutes total, mostly waiting for DNS to propagate.
+
+## Why Resend
+
+- Single API key, no separate "username" / "server token" dance.
+- Free tier: 100 emails/day, 3,000/month — comfortably above baltimore.ai's projected volume for at least the first 6 months.
+- Clean dashboard, useful per-message debugging, no marketing fluff.
+
+## Steps
+
+### 1. Sign up (1 minute)
+
+[resend.com/signup](https://resend.com/signup) → use your real email. No credit card required for the free tier.
+
+### 2. Add and verify the sender domain (5-10 minutes including DNS propagation)
+
+In Resend → **Domains** → **Add Domain** → enter `baltimore.ai`.
+
+Resend will give you 3-4 DNS records to add at your registrar (Marcaria right now):
+
+| Type | Name | Value | Purpose |
+|---|---|---|---|
+| MX | `send` | `feedback-smtp.us-east-1.amazonses.com` (priority 10) | Bounce/feedback handling |
+| TXT | `send` | `v=spf1 include:amazonses.com ~all` | SPF |
+| TXT | `resend._domainkey` | `p=...` (long key Resend provides) | DKIM |
+| TXT | `_dmarc` (optional but recommended) | `v=DMARC1; p=none;` | DMARC monitoring |
+
+Add them at Marcaria, then wait. Resend's verification typically clears within 5-10 minutes once Cloudflare's resolver sees the records.
+
+### 3. Create an API key (30 seconds)
+
+In Resend → **API Keys** → **Create API Key** → name it `baltimore-ai-production` → permission: **Sending access** (not Full access — least privilege).
+
+Copy the key (`re_xxxxxxxxxxxxxxxxxxxxxxx`) somewhere safe. **Resend only shows it once.**
+
+### 4. Set the Fly secret (10 seconds)
+
+```sh
+fly secrets set --app baltimore-ai SMTP_PASSWORD=re_xxxxxxxxxxxxxxxxxxxxxxx
+```
+
+That's the only secret needed. The other SMTP env vars (`SMTP_ADDRESS=smtp.resend.com`, `SMTP_PORT=587`, `SMTP_USERNAME=resend`) have sensible defaults in `config/environments/production.rb`.
+
+Fly will automatically redeploy the running machine to pick up the new secret.
+
+### 5. Verify end-to-end (1 minute)
+
+Submit the contact form on the live site at https://baltimore.ai/contact. The message should arrive at `ADMIN_EMAIL` within ~30 seconds. Then check Resend's **Emails** dashboard to confirm delivery.
+
+If the email doesn't arrive:
+
+- **Check Resend's dashboard first.** It'll show whether the message left Resend (delivery succeeded) or got bounced/rejected.
+- `fly logs --app baltimore-ai` — look for `ContactMessageMailer` lines.
+- If Rails says delivery succeeded but the email never arrives, your sender domain probably isn't fully verified yet. Wait 5 more minutes for DNS, then check Resend's Domains page.
+
+## What we send via Resend
+
+| Mailer | Trigger | Recipient |
+|---|---|---|
+| `ContactMessageMailer#notify_admin` | Contact form submission | `ADMIN_EMAIL` |
+| `SessionMailer#magic_link` | User requests sign-in | The user |
+| `ProfileClaimMailer#verification_code` | User initiates a listing claim | The claimant |
+| `ProfileClaimMailer#admin_new_claim` | Non-domain-match claim needs review | `ADMIN_EMAIL` |
+| `ProfileClaimMailer#welcome` | Claim completed | The new owner |
+
+All five run through `deliver_later` (Solid Queue) — Resend handles them async.
+
+## Costs
+
+Free tier covers everything until baltimore.ai is doing real volume:
+
+- 100 emails/day, 3,000/month free.
+- Pro tier ($20/mo) bumps to 50,000/month if you ever need it.
+
+For baltimore.ai's launch volume, you're going to use ~5-50 emails per month for the first quarter. The free tier is fine indefinitely.
+
+## Domain alternatives
+
+If you don't want to verify `baltimore.ai` itself (e.g. you want to keep MX records on a different provider), Resend also supports sending from a subdomain like `mail.baltimore.ai`. Update `MAIL_FROM` accordingly:
+
+```sh
+fly secrets set MAIL_FROM="Baltimore.ai <hello@mail.baltimore.ai>"
+```
+
+Same DNS records, just on the subdomain instead of the apex.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Domain stuck in "Verifying" | DNS not propagated | Wait 10 min; check with `dig TXT resend._domainkey.baltimore.ai @1.1.1.1` |
+| Rails logs "delivery succeeded" but no email | Domain not yet verified | Verify in Resend dashboard before sending real mail |
+| Resend dashboard shows "Bounced" | Recipient's mail server rejected it | Check the bounce reason — usually a typo'd address |
+| All emails going to spam | Missing DMARC | Add the `_dmarc` TXT record from Step 2 |


### PR DESCRIPTION
## Summary

Swap the production mailer's default SMTP target from Postmark to Resend (user preference). The change is comment-and-default-only — the same env-var-driven SMTP logic from the existing config still applies; just with different defaults.

**What changed:**
- `config/environments/production.rb` defaults `SMTP_ADDRESS` to `smtp.resend.com`, `SMTP_USERNAME` to `resend` (Resend's literal SMTP username). Gates on `SMTP_PASSWORD` instead of `SMTP_USERNAME` since Resend needs a single API key, not a username/password pair.
- `docs/DEPLOY.md` updated with the shorter Resend snippet.
- New `docs/RESEND_SETUP.md` — 15-minute walkthrough from account → domain verification → API key → `fly secrets set` → smoke test. Includes the DNS record table and a troubleshooting section.

**What didn't change:**
- Mailer code: `ApplicationMailer`, `ContactMessageMailer`, `SessionMailer`, `ProfileClaimMailer` are unchanged. They use whatever SMTP the environment provides.
- Dev: still uses `letter_opener`.
- Test: still uses `:test` delivery method.

## Testing

- 12/12 integration tests green
- Rubocop clean (59 files, 0 offenses)
- Production deploy will continue to work without `SMTP_PASSWORD` set — `if ENV["SMTP_PASSWORD"].present?` gates the SMTP block, so it falls through to the no-mail default until the secret is configured

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a config-comment + docs-only change with no behavior difference until `SMTP_PASSWORD` is set in production. Real validation happens when the user follows RESEND_SETUP.md and submits a contact form on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)